### PR TITLE
 #618 ported smvStrCat to Python

### DIFF
--- a/src/main/scala/org/tresamigos/smv/package.scala
+++ b/src/main/scala/org/tresamigos/smv/package.scala
@@ -150,20 +150,22 @@ package object smv {
    **/
   def smvFirst(c: Column, nonNull: Boolean = false) = smvfuncs.smvFirst(c, nonNull)
 
-  /** True if any of the columns is not null */
-  def hasNonNull(columns: Column*) = columns.foldRight(lit(false))((c, acc) => acc || c.isNotNull)
+  /** True if any of the columns is not null
+   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
+   **/
+  def hasNonNull(columns: Column*) = smvfuncs.smvHasNonNull(columns: _*)
 
   /**
    * Patch Spark's `concat` and `concat_ws` to treat null as empty string in concatenation.
+   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
    **/
-  def smvStrCat(columns: Column*) =
-    when(hasNonNull(columns: _*), concat(columns.map { c =>
-      coalesce(c, lit(""))
-    }: _*)).otherwise(lit(null))
+  def smvStrCat(columns: Column*) = smvfuncs.smvStrCat(columns: _*)
 
-  def smvStrCat(sep: String, columns: Column*) =
-    when(hasNonNull(columns: _*), concat_ws(sep, columns.map(c => coalesce(c, lit(""))): _*))
-      .otherwise(lit(null))
+  /**
+   * Patch Spark's `concat` and `concat_ws` to treat null as empty string in concatenation.
+   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
+   **/
+  def smvStrCat(sep: String, columns: Column*) = smvfuncs.smvStrCat(sep, columns: _*)
 
   /**
    * create a UDF from a map

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -145,6 +145,10 @@ object SmvPythonHelper {
     val dt = DataType.fromJson(datatypeJson)
     smvfuncs.smvCollectSet(col, dt)
   }
+
+  def smvStrCat(sep: String, cols: Array[Column]): Column = {
+    smvfuncs.smvStrCat(sep, cols: _*)
+  }
 }
 
 class SmvGroupedDataAdaptor(grouped: SmvGroupedData) {

--- a/src/main/scala/org/tresamigos/smv/smvfuncs.scala
+++ b/src/main/scala/org/tresamigos/smv/smvfuncs.scala
@@ -118,6 +118,21 @@ object smvfuncs {
 
   def smvArrayCat(sep: String, col: Column): Column = smvArrayCat(sep, col, {x:Any => x.toString})
 
+  /** True if any of the columns is not null */
+  def smvHasNonNull(columns: Column*) = columns.foldRight(lit(false))((c, acc) => acc || c.isNotNull)
+
+  /**
+   * Patch Spark's `concat` and `concat_ws` to treat null as empty string in concatenation.
+   **/
+  def smvStrCat(columns: Column*) =
+    when(smvHasNonNull(columns: _*), concat(columns.map { c =>
+      coalesce(c, lit(""))
+    }: _*)).otherwise(lit(null)).alias(s"smvStrCat(${columns.mkString(", ")})")
+
+  def smvStrCat(sep: String, columns: Column*) =
+    when(smvHasNonNull(columns: _*), concat_ws(sep, columns.map(c => coalesce(c, lit(""))): _*))
+      .otherwise(lit(null)).alias(s"smvStrCat($sep, ${columns.mkString(", ")})")
+
   /**
    * Creating unique id from the primary key list.
    *

--- a/src/test/python/testSmvfuncs.py
+++ b/src/test/python/testSmvfuncs.py
@@ -87,3 +87,9 @@ class SmvfuncsTest(SmvBaseTest):
         res = df.agg(smvArrayCat("_", sort_array(smvCollectSet(df.a, StringType()))).alias("aa"))
         exp = self.createDF("aa: String", "a_b_c")
         self.should_be_same(res, exp)
+
+    def test_smvStrCat(self):
+        df = self.createDF("a:String;b:Integer", "a,1;b,2;c,")
+        res = df.select(smvStrCat("_", df.a, df.b).alias("a_b"))
+        exp = self.createDF("a_b: String", "a_1;b_2;c_")
+        self.should_be_same(res, exp)


### PR DESCRIPTION
* Scala side, moved smvStrCat to smvfuncs from package, while still kept the version in package (labeled deprecated)
* Implemented smvStrCat on Python side with docstr
* Created test on Python side