### PR TITLE
Copy generated `smv-profile.sh` to the SMV tools directory 

### DIFF
--- a/tools/smv-install
+++ b/tools/smv-install
@@ -23,7 +23,8 @@ function parse_args()
 
   SMV_DIR="SMV_${SMV_VERSION}"
   SPARK_DIR="spark-1.5.2-bin-2.7.2"
-  SMV_PROFILE="${HOME}/.smv/smv-profile.sh"
+  SMV_PROFILE_FILENAME="smv-profile.sh"
+  SMV_PROFILE="${HOME}/.smv/${SMV_PROFILE_FILENAME}"
 
   validate_version
 }
@@ -122,6 +123,9 @@ generate_profile_file() {
     echo 'export PATH="'${install_dir}/${SPARK_DIR}/bin':${PATH}"' >> ${SMV_PROFILE}
   fi
   echo "[INFO] created ${SMV_PROFILE}"
+  COPIED_SMV_PROFILE_PATH="${SMV_DIR}/tools/${SMV_PROFILE_FILENAME}"
+  cp "${SMV_PROFILE}" "${COPIED_SMV_PROFILE_PATH}"
+  echo "[INFO] copied SMV profile to ${COPIED_SMV_PROFILE_PATH}"
 }
 
 # add a call in users "profile" file to source the generated SMV profile file


### PR DESCRIPTION
Copy generated `smv-profile.sh` to the SMV tools directory 

The purpose of this change is to accommodate use cases where SMV is installed to a shared location, and non-installing users do not have permission to access the profile file written to the installing user's home directory