### PR TITLE
SmvModuleLink datasetHash should vary with target module (#607)

### DIFF
--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -613,7 +613,9 @@ class SmvModuleLink(val outputModule: SmvOutput)
 
   /**
    * If the depended smvModule has a published version, SmvModuleLink's datasetHash
-   * depends on the version string. Otherwise, depends on the smvModule's hashOfHash
+   * depends on the version string and the target's FQN (even with versioned data
+   * the hash should change if the target changes). Otherwise, depends on the 
+   * smvModule's hashOfHash
    **/
   override def datasetHash() = {
     val dependedHash = smvModule.stageVersion

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -619,7 +619,7 @@ class SmvModuleLink(val outputModule: SmvOutput)
     val dependedHash = smvModule.stageVersion
       .map { v =>
         val crc = new java.util.zip.CRC32
-        crc.update(v.toCharArray.map(_.toByte))
+        crc.update((v + smvModule.fqn).toCharArray.map(_.toByte))
         (crc.getValue).toInt
       }
       .getOrElse(smvModule.hashOfHash)
@@ -630,8 +630,10 @@ class SmvModuleLink(val outputModule: SmvOutput)
   /**
    * SmvModuleLinks should not cache or validate their data
    */
-  override def computeRDD = throw new SmvRuntimeException("SmvModuleLink computeRDD should never be called")
-  override private[smv] def doRun(dsDqm: DQMValidator) = throw new SmvRuntimeException("SmvModuleLink doRun should never be called")
+  override def computeRDD =
+    throw new SmvRuntimeException("SmvModuleLink computeRDD should never be called")
+  override private[smv] def doRun(dsDqm: DQMValidator) =
+    throw new SmvRuntimeException("SmvModuleLink doRun should never be called")
 
   /**
    * "Running" a link requires that we read the published output from the upstream `DataSet`.

--- a/src/test/scala/org/tresamigos/smv/SmvLinkFollowTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvLinkFollowTest.scala
@@ -47,7 +47,7 @@ package org.tresamigos.smv {
     /* Since DS will cache the resolved DF we need to use a separate Y for SmvLinkFollowWithVersionTest */
     test("Test SmvModuleLink datasetHash follow link version") {
       val res = smvLinkTestPkg2.L2.datasetHash()
-      assert(res === -1307514264l) // when version = v1
+      assert(res === -1657727345) // when version = v1
     }
 
     test("Test SmvModuleLink follow link with version config") {

--- a/src/test/scala/org/tresamigos/smv/SmvModuleLinkHashTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvModuleLinkHashTest.scala
@@ -1,0 +1,42 @@
+/*
+ * This file is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tresamigos.smv
+
+class SmvModuleLinkHashTest extends SmvTestUtil {
+  override def appArgs =
+    Seq("--smv-props",
+        "smv.stages=org.tresamigos.smv.S1:org.tresamigos.smv.S2",
+        "smv.stages.org.tresamigos.smv.S2.version=1")
+
+  test("Test SmvModuleLinks with different FQN have different hash") {
+    assert(S1.LX.datasetHash != S1.LY.datasetHash)
+  }
+}
+
+package object S1 {
+  val LX = new SmvModuleLink(S2.X)
+  val LY = new SmvModuleLink(S2.Y)
+}
+
+package S2 {
+  object X extends SmvModule("") with SmvOutput {
+    def run(i: runParams) = null
+    def requiresDS        = Seq()
+  }
+  object Y extends SmvModule("") with SmvOutput {
+    def run(i: runParams) = null
+    def requiresDS        = Seq()
+  }
+}


### PR DESCRIPTION
Addressing #607. Because this changes `SmvModuleLinks'` `datasetHash`, I had to update a test that was asserting that an `SmvModuleLink's` `datasetHash` was equal to a hard-coded value. We should find an alternative to these hardcoded values.