### PR TITLE
add optional flag for df to force module to rerun (#643)

### DIFF
--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -142,14 +142,14 @@ class SmvApp(object):
         """
         return self.j_smvApp.generateAllGraphJSON()
 
-    def runModule(self, urn):
+    def runModule(self, urn, force = False):
         """Runs either a Scala or a Python SmvModule by its Fully Qualified Name(fqn)
         """
-        jdf = self.j_smvPyClient.runModule(urn)
+        jdf = self.j_smvPyClient.runModule(urn, force)
         return DataFrame(jdf, self.sqlContext)
 
-    def runModuleByName(self, name):
-        jdf = self.j_smvApp.runModuleByName(name)
+    def runModuleByName(self, name, force = False):
+        jdf = self.j_smvApp.runModuleByName(name, force)
         return DataFrame(jdf, self.sqlContext)
 
     def urn2fqn(self, urnOrFqn):

--- a/src/main/python/smv/smvpydataset.py
+++ b/src/main/python/smv/smvpydataset.py
@@ -425,7 +425,7 @@ class SmvHiveTable(SmvPyInput):
         return None
 
     def doRun(self, validator, known):
-        return self.run(DataFrame(self._smvHiveTable.rdd(), self.smvApp.sqlContext))
+        return self.run(DataFrame(self._smvHiveTable.rdd(False), self.smvApp.sqlContext))
 
 class SmvModule(SmvPyDataSet):
     """Base class for SmvModules written in Python

--- a/src/main/python/smvshell.py
+++ b/src/main/python/smvshell.py
@@ -18,9 +18,12 @@ from smv import CsvAttributes
 
 jvmShellCmd = SmvApp.getInstance()._jvm.org.tresamigos.smv.shell.ShellCmd
 
-df = lambda name: SmvApp.getInstance().runModuleByName(name)
+def df(name, force = False):
+    return SmvApp.getInstance().runModuleByName(name, force)
+
 def ddf(fqn):
     print "ddf has been removed. df now runs modules dynamically. Use df instead of ddf."
+
 def pdf(fqn):
     print "pdf has been removed. Run modules dynamically with df instead."
 

--- a/src/main/scala/org/tresamigos/smv/SmvAncillery.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvAncillery.scala
@@ -21,7 +21,7 @@ abstract class SmvAncillary {
   lazy val resolvedRequiresDS = requiresDS()
 
   protected def getDF(ds: SmvModuleLink): DataFrame = {
-    if (resolvedRequiresDS.contains(ds)) ds.rdd
+    if (resolvedRequiresDS.contains(ds)) ds.rdd()
     else throw new SmvRuntimeException(s"${ds} does not defined in requiresDS")
   }
 }

--- a/src/main/scala/org/tresamigos/smv/SmvHierarchy.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvHierarchy.scala
@@ -48,7 +48,7 @@ case class SmvHierarchy(
 ) {
   private val hierCols = new SmvHierarchyColumns(name + "_map")
 
-  private[smv] lazy val mapDF = hierarchyMap.asInstanceOf[SmvDataSet].rdd
+  private[smv] lazy val mapDF = hierarchyMap.asInstanceOf[SmvDataSet].rdd()
 
   private lazy val mapWithNameAndParent = hierarchy
     .zip(hierarchy.tail :+ (null: String))

--- a/src/main/scala/org/tresamigos/smv/dqm/SmvDQM.scala
+++ b/src/main/scala/org/tresamigos/smv/dqm/SmvDQM.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.functions.udf
  * like "count" might be optimized so that transformations which have no impact on "count" might be
  * totally ignored. If there no natural action to be apply, you may need to do convert DF to RDD first
  * {{{
- * dfWithDqm.rdd.count
+ * dfWithDqm.rdd().count
  * }}}
  * After the action, we can check the policies
  * {{{

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -219,8 +219,8 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   def urn2fqn(modUrn: String): String = org.tresamigos.smv.urn2fqn(modUrn)
 
   /** Runs an SmvModule written in either Python or Scala */
-  def runModule(urn: String): DataFrame =
-    j_smvApp.runModule(URN(urn))
+  def runModule(urn: String, force: Boolean): DataFrame =
+    j_smvApp.runModule(URN(urn), force)
 
   // TODO: The following method should be removed when Scala side can
   // handle publish-hive SmvPyOutput tables

--- a/src/test/scala/org/tresamigos/smv/CsvTest.scala
+++ b/src/test/scala/org/tresamigos/smv/CsvTest.scala
@@ -7,7 +7,7 @@ class CsvTest extends SmvTestUtil {
 
   test("Test loading of csv file with header") {
     val file = SmvCsvFile("./" + testDataDir + "CsvTest/test1", CsvAttributes.defaultCsvWithHeader)
-    val df   = file.rdd
+    val df   = file.rdd()
     val res  = df.map(r => (r(0), r(1))).collect.mkString(",")
     // TODO: should probably add a assertSRDDEqual() with expected rows instead of convert to string
     assert(res === "(Bob,1),(Fred,2)")
@@ -32,7 +32,7 @@ class CsvTest extends SmvTestUtil {
         df.smvSelectPlus(smvStrCat($"name", $"id") as "name_id")
       }
     }
-    val df = TestFile.rdd
+    val df = TestFile.rdd()
     assertSrddDataEqual(df,
                         "Bob,1,Bob1;" +
                           "Fred,2,Fred2")
@@ -40,7 +40,7 @@ class CsvTest extends SmvTestUtil {
 
   test("Test reading CSV file with attributes in schema file.") {
     val file = SmvCsvFile("./" + testDataDir + "CsvTest/test2.csv")
-    val df   = file.rdd
+    val df   = file.rdd()
 
     // take the sum of second column (age) to make sure csv was interpreted correctly.
     val res = df.agg(sum(df("age")))
@@ -109,7 +109,7 @@ class CsvTest extends SmvTestUtil {
                     |Fred,24;
                     |"Joe,50""".stripMargin
               )
-    assertDataFramesEqual(file.rdd, exp)
+    assertDataFramesEqual(file.rdd(), exp)
   }
 
   test("Write file with \" as content instead of quote-char") {
@@ -122,7 +122,7 @@ class CsvTest extends SmvTestUtil {
     res.saveAsCsvWithSchema(csvPath)
 
     val fileOut = SmvCsvFile("./" + csvPath)
-    assertDataFramesEqual(fileOut.rdd, res)
+    assertDataFramesEqual(fileOut.rdd(), res)
   }
 
   test("Test escaping quotes in strings") {
@@ -157,7 +157,7 @@ class CsvTest extends SmvTestUtil {
 
     df.saveAsCsvWithSchema(csvPathCaret, ca)
     val file = SmvCsvFile("./" + csvPathCaret, ca)
-    dfOut = file.rdd
+    dfOut = file.rdd()
 
     assertDataFramesEqual(df, dfOut)
 

--- a/src/test/scala/org/tresamigos/smv/DQMTest.scala
+++ b/src/test/scala/org/tresamigos/smv/DQMTest.scala
@@ -168,7 +168,7 @@ class DQMTest extends SmvTestUtil {
           .add(FailTotalFixCountPolicy(1))
     }
     intercept[SmvDqmValidationError] {
-      file.rdd.show
+      file.rdd().show
     }
   }
 
@@ -184,7 +184,7 @@ class DQMTest extends SmvTestUtil {
           .add(FailTotalRuleCountPolicy(3))
     }
     intercept[SmvDqmValidationError] {
-      file.rdd.show
+      file.rdd().show
     }
   }
 
@@ -198,7 +198,7 @@ class DQMTest extends SmvTestUtil {
           .add(FormatFix($"c", ".", "_"))
           .add(FailTotalFixCountPolicy(5))
     }
-    assertSrddDataEqual(file.rdd, "1,m,a;0,f,c;2,m,z;1,o,x;1,m,_")
+    assertSrddDataEqual(file.rdd(), "1,m,a;0,f,c;2,m,z;1,o,x;1,m,_")
   }
 
   test("test user defined policy") {
@@ -215,7 +215,7 @@ class DQMTest extends SmvTestUtil {
     }
 
     intercept[SmvDqmValidationError] {
-      file.rdd
+      file.rdd()
     }
   }
 }

--- a/src/test/scala/org/tresamigos/smv/DSDependencyTest.scala
+++ b/src/test/scala/org/tresamigos/smv/DSDependencyTest.scala
@@ -23,9 +23,9 @@ package org.tresamigos.smv {
     /* TODO: turn on dependency check when tests on all the projects
   test("test dependency check on SmvAncillary") {
     intercept[IllegalArgumentException] {
-      val f = org.tresamigos.smv.dsdependencyPkg.B.rdd
+      val f = org.tresamigos.smv.dsdependencyPkg.B.rdd()
     }
-    val g = org.tresamigos.smv.dsdependencyPkg.C.rdd
+    val g = org.tresamigos.smv.dsdependencyPkg.C.rdd()
   }
    */
   }

--- a/src/test/scala/org/tresamigos/smv/PublishTest.scala
+++ b/src/test/scala/org/tresamigos/smv/PublishTest.scala
@@ -37,7 +37,7 @@ package org.tresamigos.smv {
       org.tresamigos.smv.publish.stage1.M1.publish()
 
       // Verify that the published file has same data/schema as the source module.
-      val df = SmvCsvFile("publish/v1/org.tresamigos.smv.publish.stage1.M1.csv").rdd
+      val df = SmvCsvFile("publish/v1/org.tresamigos.smv.publish.stage1.M1.csv").rdd()
       assertSrddSchemaEqual(df, "x:Integer")
       assertSrddDataEqual(df, "1;2;3")
 

--- a/src/test/scala/org/tresamigos/smv/RejectTest.scala
+++ b/src/test/scala/org/tresamigos/smv/RejectTest.scala
@@ -23,7 +23,7 @@ class RejectTest extends SmvTestUtil {
         extends SmvCsvFile("./" + testDataDir + "RejectTest/test2", CsvAttributes.defaultCsv) {
       override val failAtParsingError = false
     }
-    val df = file.rdd
+    val df = file.rdd()
 
     val res = df.collect.map(_.mkString(","))
     val exp = List(
@@ -62,7 +62,7 @@ class RejectTest extends SmvTestUtil {
       override val failAtParsingError = false
       override def dqm()              = SmvDQM().add(FailParserCountPolicy(10))
     }
-    val df  = file.rdd
+    val df  = file.rdd()
     val res = ValidationResult(SmvReportIO.readReport(file.moduleValidPath()))
     assert(res.passed === true)
     assertUnorderedSeqEqual(res.errorMessages, Seq(("FailParserCountPolicy(10)", "true")))
@@ -94,7 +94,7 @@ class RejectTest extends SmvTestUtil {
     object smvCF extends SmvCsvStringData(schemaStr, data, true) {
       override val failAtParsingError = false
     }
-    val prdd = smvCF.rdd
+    val prdd = smvCF.rdd()
 
     val res = SmvReportIO.readReport(smvCF.moduleValidPath())
 

--- a/src/test/scala/org/tresamigos/smv/SmvFileTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvFileTest.scala
@@ -35,10 +35,10 @@ class SmvFileTest extends SmvTestUtil {
     createTempFile("input/a.schema", "f1: String")
 
     object File1 extends SmvCsvFile("a.csv")
-    val res1 = File1.rdd
+    val res1 = File1.rdd()
 
     object File2 extends SmvCsvFile("input/a.csv")
-    val res2 = File2.rdd
+    val res2 = File2.rdd()
 
     assertSrddDataEqual(res1, "a")
     assertSrddDataEqual(res2, "a")
@@ -68,7 +68,7 @@ class SmvFileTest extends SmvTestUtil {
 
     object Data1 extends SmvMultiCsvFiles("data1")
 
-    val res = Data1.rdd
+    val res = Data1.rdd()
     assertSrddDataEqual(res, "a;b")
   }
 }

--- a/src/test/scala/org/tresamigos/smv/SmvForceRunTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvForceRunTest.scala
@@ -14,16 +14,15 @@
 
 package org.tresamigos.smv
 
-class FrlTest extends SmvTestUtil {
-  test("test frlFile loader with NoOp rejectlogger") {
-    object file extends SmvFrlFile("./" + testDataDir + "FrlTest/test") {
-      override val failAtParsingError = false
-    }
+class SmvForceRunTest extends SmvTestUtil {
+  object X extends SmvModule("X") {
+    def requiresDS() = Seq()
+    def run(i: runParams) = dfFrom("k:String","")
+  }
 
-    val res = file.rdd()
-
-    assertSrddSchemaEqual(res, "id: String; v: String")
-    assertUnorderedSeqEqual(res.collect.map(_.toString),
-                            Seq("[12,34]", "[23,45]", "[12,00]", "[qa,da]"))
+  test("Test forcing module to run skips the DataFrame cache") {
+    val rdd1 = X.rdd()
+    val rdd2 = X.rdd(true)
+    assert(rdd1 !== rdd2)
   }
 }

--- a/src/test/scala/org/tresamigos/smv/SmvHierarchyTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvHierarchyTest.scala
@@ -115,8 +115,8 @@ package org.tresamigos.smv {
         }
       }
 
-      hierTestPkg1.GeoMapFile.rdd
-      val res = TestModule.rdd
+      hierTestPkg1.GeoMapFile.rdd()
+      val res = TestModule.rdd()
 
       assertSrddDataEqual(
         res,

--- a/src/test/scala/org/tresamigos/smv/SmvModuleNeedsToRunTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvModuleNeedsToRunTest.scala
@@ -27,7 +27,7 @@ package org.tresamigos.smv {
     test("Persisted modules should return false for needsToRun") {
       val m = load(needstoruntest.Mod2)
       m.deleteOutputs()
-      m.rdd
+      m.rdd()
       m.needsToRun shouldBe false
       m.deleteOutputs()
     }
@@ -35,7 +35,7 @@ package org.tresamigos.smv {
     test("Persisted but modified modules should return true for needsToRun") {
       val m = load(needstoruntest.Mod3)
       m.deleteOutputs()
-      m.rdd
+      m.rdd()
       m.deleteOutputs()
       m.needsToRun shouldBe true
     }
@@ -43,7 +43,7 @@ package org.tresamigos.smv {
     test("Modules depending on persisted but modified modules should return true for needsToRun") {
       val Seq(m3, m4) = loadM(needstoruntest.Mod3, needstoruntest.Mod4)
 
-      m3.rdd
+      m3.rdd()
       m3.deleteOutputs()
 
       assume(m4.resolvedRequiresDS.contains(m3))

--- a/src/test/scala/org/tresamigos/smv/SparkTestUtil.scala
+++ b/src/test/scala/org/tresamigos/smv/SparkTestUtil.scala
@@ -236,7 +236,7 @@ trait SmvTestUtil extends SparkTestUtil {
 
   def open(path: String) = {
     val file = SmvCsvFile("./" + path, CsvAttributes.defaultCsv)
-    file.rdd
+    file.rdd()
   }
 
   def dfFrom(schemaStr: String, data: String): DataFrame = app.createDF(schemaStr, data)


### PR DESCRIPTION
Addressing (#643). The majority of this commit is adding parentheses to calls to `DataFrame.rdd` - you can't leave of parentheses if there is a default parameter. It should be a short leap from here to #481.