### PR TITLE
I599 deprecation warn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,3 +58,5 @@ assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeSca
 assemblyJarName in assembly := s"${name.value}-${version.value}-jar-with-dependencies.jar"
 
 test in assembly := {}
+
+initialize ~= { _ => sys.props("scalac.patmat.analysisBudget") = "off" }

--- a/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
@@ -995,7 +995,7 @@ class SmvDFHelper(df: DataFrame) {
       when($"${newkey}".isNull, "0").otherwise("1")
     }
 
-    joined.select($"${key}", smvStrCat(hasCols: _*) as "flag")
+    joined.select($"${key}", smvfuncs.smvStrCat(hasCols: _*) as "flag")
   }
 
   /**

--- a/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
@@ -1497,7 +1497,7 @@ class SmvDFHelper(df: DataFrame) {
       }
       .map {
         case (cols, name) =>
-          smvStrCat("_", cols.map { c =>
+          smvfuncs.smvStrCat("_", cols.map { c =>
             $"$c"
           }: _*).as(name)
       }

--- a/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDFHelper.scala
@@ -427,7 +427,7 @@ class SmvDFHelper(df: DataFrame) {
     val selectExpressions = df.columns.diff(keys).map {
       //using smvFirst instead of first, since `first` return the first non-null of each field
       fn =>
-        smvFirst($"$fn") as fn
+        smvfuncs.smvFirst($"$fn") as fn
     }
 
     if (selectExpressions.isEmpty) {

--- a/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
@@ -897,7 +897,7 @@ class SmvGroupedDataFunc(smvGD: SmvGroupedData) {
       }
       .map {
         case (cols, name) =>
-          smvStrCat("_", cols.map { c =>
+          smvfuncs.smvStrCat("_", cols.map { c =>
             $"$c"
           }: _*).as(name)
       }

--- a/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
@@ -834,7 +834,7 @@ class SmvGroupedDataFunc(smvGD: SmvGroupedData) {
     val keyColsStr = keys.map { k =>
       df(k).cast("string")
     }
-    val keyDf = df.selectPlusPrefix(smvStrCat(keyColsStr: _*) as "_smvRePartition_key_")
+    val keyDf = df.selectPlusPrefix(smvfuncs.smvStrCat(keyColsStr: _*) as "_smvRePartition_key_")
 
     val resRdd = keyDf.rdd
       .keyBy({ r =>

--- a/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvGroupedData.scala
@@ -266,7 +266,7 @@ class SmvGroupedDataFunc(smvGD: SmvGroupedData) {
     val pivotRes = SmvGroupedData(pivot.createSrdd(dfp, keys), keys)
 
     // collapse each group into 1 row
-    val cols = pivot.outCols map (n => smvFirst($"$n", true) as n)
+    val cols = pivot.outCols map (n => smvfuncs.smvFirst($"$n", true) as n)
     pivotRes.agg(cols(0), cols.tail: _*)
   }
 

--- a/src/main/scala/org/tresamigos/smv/SmvHierarchy.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvHierarchy.scala
@@ -436,7 +436,7 @@ class SmvHierarchies(
    *
    * Example:
    * {{{
-   * ProdHier.levelRollup(df, "h1", "h2")(sum($"v1") as "v1", ...)()
+   * ProdHier.levelRollup(df, "h1", "h2")(sum(\$"v1") as "v1", ...)()
    * }}}
    *
    * The result will not depend of the paremerter order of "h1" and "h2"
@@ -456,7 +456,7 @@ class SmvHierarchies(
    *
    * The result will be
    * {{{
-   * ${prefix}_type, ${prefix}_value, v1
+   * \${prefix}_type, \${prefix}_value, v1
    * h1,        1,          6.0
    * h1,        2,          3.0
    * h2,        02,         3.0
@@ -488,7 +488,7 @@ class SmvHierarchies(
    * one need to copy the key to a new column and then apply the aggregate funtion on
    * the new column, like the following,
    * {{{
-   * df.smvSelectPlus($"b" as "newb").rollup("a", "b").agg(count("newb") as "n")
+   * df.smvSelectPlus(\$"b" as "newb").rollup("a", "b").agg(count("newb") as "n")
    * }}}
    *
    *

--- a/src/main/scala/org/tresamigos/smv/SmvPivot.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvPivot.scala
@@ -167,7 +167,7 @@ private[smv] object SmvPivot {
     })
     pivotColsSets.map { pivotCols =>
       val colNames = df
-        .select(smvStrCat("_", pivotCols.map { s =>
+        .select(smvfuncs.smvStrCat("_", pivotCols.map { s =>
           normStr(df(s).cast(StringType))
         }: _*))
         .distinct

--- a/src/main/scala/org/tresamigos/smv/dqm/DQMTask.scala
+++ b/src/main/scala/org/tresamigos/smv/dqm/DQMTask.scala
@@ -86,7 +86,7 @@ case class DQMRule(
 
     val logColName = s"${name}_log"
     /* Will log references columns for each rule */
-    val logCol = smvStrCat(catCols: _*).as(logColName)
+    val logCol = smvfuncs.smvStrCat(catCols: _*).as(logColName)
 
     val _name = name
     val filterUdf = udf({ (c: Boolean, logStr: String) =>

--- a/src/main/scala/org/tresamigos/smv/edd/EddTaskGroup.scala
+++ b/src/main/scala/org/tresamigos/smv/edd/EddTaskGroup.scala
@@ -71,7 +71,7 @@ private[smv] abstract class EddTaskGroup {
     } else {
       // on row per group
       val dfGd = df
-        .smvSelectPlus(smvStrCat("_", keys.map { c =>
+        .smvSelectPlus(smvfuncs.smvStrCat("_", keys.map { c =>
           $"$c"
         }: _*) as "groupKey")
         .groupBy("groupKey")

--- a/src/main/scala/org/tresamigos/smv/package.scala
+++ b/src/main/scala/org/tresamigos/smv/package.scala
@@ -141,9 +141,8 @@ package object smv {
    * @param nonNull  switches whether the function will try to find the first non-null value
    *
    * @group agg
-   *
    **/
- @deprecated("use the one in smvfuncs package instead", "1.6")
+  @deprecated("use the one in smvfuncs package instead", "1.6")
   def smvFirst(c: Column, nonNull: Boolean = false) = smvfuncs.smvFirst(c, nonNull)
 
   /** True if any of the columns is not null
@@ -159,8 +158,8 @@ package object smv {
 
   /**
    * Patch Spark's `concat` and `concat_ws` to treat null as empty string in concatenation.
-   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
    **/
+  @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
   def smvStrCat(sep: String, columns: Column*) = smvfuncs.smvStrCat(sep, columns: _*)
 
   /**

--- a/src/main/scala/org/tresamigos/smv/package.scala
+++ b/src/main/scala/org/tresamigos/smv/package.scala
@@ -146,8 +146,8 @@ package object smv {
   def smvFirst(c: Column, nonNull: Boolean = false) = smvfuncs.smvFirst(c, nonNull)
 
   /** True if any of the columns is not null
-   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
    **/
+  @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
   def hasNonNull(columns: Column*) = smvfuncs.smvHasNonNull(columns: _*)
 
   /**

--- a/src/main/scala/org/tresamigos/smv/package.scala
+++ b/src/main/scala/org/tresamigos/smv/package.scala
@@ -141,8 +141,9 @@ package object smv {
    * @param nonNull  switches whether the function will try to find the first non-null value
    *
    * @group agg
-   * @deprecated("use the one in smvfuncs package instead", "1.6")
+   *
    **/
+ @deprecated("use the one in smvfuncs package instead", "1.6")
   def smvFirst(c: Column, nonNull: Boolean = false) = smvfuncs.smvFirst(c, nonNull)
 
   /** True if any of the columns is not null

--- a/src/main/scala/org/tresamigos/smv/package.scala
+++ b/src/main/scala/org/tresamigos/smv/package.scala
@@ -152,8 +152,8 @@ package object smv {
 
   /**
    * Patch Spark's `concat` and `concat_ws` to treat null as empty string in concatenation.
-   * @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
    **/
+  @deprecated("use smvHasNonNull in smvfuncs package instead", "2.1")
   def smvStrCat(columns: Column*) = smvfuncs.smvStrCat(columns: _*)
 
   /**

--- a/src/test/scala/org/tresamigos/smv/AggFuncsTest.scala
+++ b/src/test/scala/org/tresamigos/smv/AggFuncsTest.scala
@@ -68,9 +68,9 @@ class AggFuncsTest extends SmvTestUtil {
     val res = df
       .groupBy("k")
       .agg(
-        smvFirst($"t", true), // use smvFirst instead of Spark's first to test the alternative form also
-        smvFirst($"v", true) as "first_v",
-        smvFirst($"v") as "smvFirst_v"
+        smvfuncs.smvFirst($"t", true), // use smvFirst instead of Spark's first to test the alternative form also
+        smvfuncs.smvFirst($"v", true) as "first_v",
+        smvfuncs.smvFirst($"v") as "smvFirst_v"
       )
 
     assertUnorderedSeqEqual(res.collect.map(_.toString), Seq("[a,1,0.3,0.3]", "[z,1,1.4,null]"))

--- a/src/test/scala/org/tresamigos/smv/CsvTest.scala
+++ b/src/test/scala/org/tresamigos/smv/CsvTest.scala
@@ -29,7 +29,7 @@ class CsvTest extends SmvTestUtil {
                            CsvAttributes.defaultCsvWithHeader) {
       override def run(df: DataFrame) = {
         import df.sqlContext.implicits._
-        df.smvSelectPlus(smvStrCat($"name", $"id") as "name_id")
+        df.smvSelectPlus(smvfuncs.smvStrCat($"name", $"id") as "name_id")
       }
     }
     val df = TestFile.rdd()
@@ -114,7 +114,7 @@ class CsvTest extends SmvTestUtil {
 
   test("Write file with \" as content instead of quote-char") {
     /* In this case res will be saved with @quote-char = ", but data will use Excel escape
-       style as """b". 
+       style as """b".
        */
     val res = dfFrom("name:String", "a").withColumn("name2", lit("\"b"))
     val csvPath = testcaseTempDir + "/test_write_data_with_quote"

--- a/src/test/scala/org/tresamigos/smv/NonAggFuncsTest.scala
+++ b/src/test/scala/org/tresamigos/smv/NonAggFuncsTest.scala
@@ -22,7 +22,7 @@ class NonAggFuncsTest extends SmvTestUtil {
   test("test smvStrCat") {
     val ssc = sqlContext; import ssc.implicits._
     val df  = dfFrom("k:String; v:String;", "1,a;2,")
-    val res = df.select(smvStrCat($"v", $"k"))
+    val res = df.select(smvfuncs.smvStrCat($"v", $"k"))
     assertSrddDataEqual(res,
                         "a1;" +
                           "2")
@@ -31,7 +31,7 @@ class NonAggFuncsTest extends SmvTestUtil {
   test("smvStrCat(ws, cols) should yield null if all columns are null") {
     val ssc = sqlContext; import ssc.implicits._
     val df  = dfFrom("k:String; v:String;", "1,a;2,;,")
-    val res = df.select(smvStrCat("-", $"v", $"k"))
+    val res = df.select(smvfuncs.smvStrCat("-", $"v", $"k"))
     assertSrddDataEqual(res, "a-1;-2;null")
   }
 


### PR DESCRIPTION
cleaned up most deprecation warnings and some others as well.

The only remaining deprecation warnings are for `chunkBy` and `chunkByPlus`, as these functions will have their interface refined.