### PR TITLE
#693: update doc links with version number

### DIFF
--- a/admin/publish_docs.sh
+++ b/admin/publish_docs.sh
@@ -46,7 +46,7 @@ function write_docs()
   SCALADOC_DIR="$OUTPUT_DIR/scaladocs"
 
   echo "-- copying scaladocs to ~/.smv/ghpages/SMV/scaladocs ..."
-  echo "-- copying pythondocs to ~/.smv/ghpages/SMV/pydocs ..."
+  echo "-- copying pythondocs to ~/.smv/ghpages/SMV/pythondocs ..."
   # put the docs in the right version subdirectory
   mkdir -p $PYVERSION_DIR
   mkdir -p $SCALAVERSION_DIR

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,4 +1,4 @@
-# FAQ 
+# FAQ
 
 ## What is SMV?
 SMV stands for "Spark Modularized View".
@@ -56,7 +56,7 @@ To create new variables (columns), you need to utilize Column operations. There 
 Spark you can find them: methods of Column class and functions object under sql package. You can find
 all the useful methods and functions on the Scala API doc from Spark.
 SMV extends both the methods and functions. The new methods and functions can be find in
-[SMV API Docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.package).
+[SMV API Docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.package).
 
 For anything which is not covered above, you can create your own "udf", User Defined Function, through
 Scala functions. Here is a simple example

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -56,7 +56,7 @@ To create new variables (columns), you need to utilize Column operations. There 
 Spark you can find them: methods of Column class and functions object under sql package. You can find
 all the useful methods and functions on the Scala API doc from Spark.
 SMV extends both the methods and functions. The new methods and functions can be find in
-[SMV API Docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.package).
+[SMV API Docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.package).
 
 For anything which is not covered above, you can create your own "udf", User Defined Function, through
 Scala functions. Here is a simple example

--- a/docs/user/functions.md
+++ b/docs/user/functions.md
@@ -20,7 +20,7 @@ df.select(
   ...)
 ```
 
-See [SMV ColumnHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.ColumnHelper) for more details.
+See [SMV ColumnHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.ColumnHelper) for more details.
 
 ## Package level Column Functions
 A group of functions can be applied to multiple Columns are defined in the smv package level.
@@ -31,7 +31,7 @@ df.select(
 )
 ```
 
-See [SMV package API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.package) for details.
+See [SMV package API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.package) for details.
 
 ## DataFrame Helper Functions
 This set of functions can be applied to an existing `DataFrame`.
@@ -41,7 +41,7 @@ df.selectPlus( $"amt" * 2 as "double_amt")
 ```
 Can be used to add an additional column to a `DataFrame`.
 
-See [SmvDFHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.SmvDFHelper) for more details.
+See [SmvDFHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.SmvDFHelper) for more details.
 
 ## Grouped Helper Functions
 This set of functions are used to augment the standard Spark `groupBy` method to provide functions that operate on grouped data.
@@ -51,13 +51,13 @@ df.smvGroupBy("id").
    smvPivotSum(Seq("month", "product"))("count")("5_14_A", "5_14_B", "6_14_A", "6_14_B")
 ```
 
-See [SmvGroupedDataFunc API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.SmvGroupedDataFunc) for more details.
+See [SmvGroupedDataFunc API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.SmvGroupedDataFunc) for more details.
 
 ## Custom Data Selector (CDS) Functions
 A Custom Data Selector (CDS) defines a sub-set of a group of records within a GroupedData,
 and user can define aggregations on this sub-set of data.
 
-See [CDS API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.cds.package) for details.
+See [CDS API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.cds.package) for details.
 
 **Note** since Spark 1.4 introduced the `window` concept, there are significant function
 overlap between SMV cds and Spark `window`. When migrate to Spark 1.5, the entire CDS interface

--- a/docs/user/functions.md
+++ b/docs/user/functions.md
@@ -20,7 +20,7 @@ df.select(
   ...)
 ```
 
-See [SMV ColumnHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.ColumnHelper) for more details.
+See [SMV ColumnHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.ColumnHelper) for more details.
 
 ## Package level Column Functions
 A group of functions can be applied to multiple Columns are defined in the smv package level.
@@ -31,7 +31,7 @@ df.select(
 )
 ```
 
-See [SMV package API docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.package) for details.
+See [SMV package API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.package) for details.
 
 ## DataFrame Helper Functions
 This set of functions can be applied to an existing `DataFrame`.
@@ -41,7 +41,7 @@ df.selectPlus( $"amt" * 2 as "double_amt")
 ```
 Can be used to add an additional column to a `DataFrame`.
 
-See [SmvDFHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.SmvDFHelper) for more details.
+See [SmvDFHelper API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.SmvDFHelper) for more details.
 
 ## Grouped Helper Functions
 This set of functions are used to augment the standard Spark `groupBy` method to provide functions that operate on grouped data.
@@ -51,13 +51,13 @@ df.smvGroupBy("id").
    smvPivotSum(Seq("month", "product"))("count")("5_14_A", "5_14_B", "6_14_A", "6_14_B")
 ```
 
-See [SmvGroupedDataFunc API docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.SmvGroupedDataFunc) for more details.
+See [SmvGroupedDataFunc API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.SmvGroupedDataFunc) for more details.
 
 ## Custom Data Selector (CDS) Functions
 A Custom Data Selector (CDS) defines a sub-set of a group of records within a GroupedData,
 and user can define aggregations on this sub-set of data.
 
-See [CDS API docs](http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.cds.package) for details.
+See [CDS API docs](http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.cds.package) for details.
 
 **Note** since Spark 1.4 introduced the `window` concept, there are significant function
 overlap between SMV cds and Spark `window`. When migrate to Spark 1.5, the entire CDS interface

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -44,7 +44,7 @@ object ShellCmd {
     """Here is a list of SMV-shell command
       |
       |Please refer to the API doc for details:
-      |http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.shell.package
+      |http://tresamigossd.github.io/SMV/scaladocs/1.5.2.8/index.html#org.tresamigos.smv.shell.package
       |
       |* lsStage
       |* ls

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -44,7 +44,7 @@ object ShellCmd {
     """Here is a list of SMV-shell command
       |
       |Please refer to the API doc for details:
-      |http://tresamigossd.github.io/SMV/scaladocs/index.html#org.tresamigos.smv.shell.package
+      |http://tresamigossd.github.io/SMV/scaladocs/1.5.2.7/index.html#org.tresamigos.smv.shell.package
       |
       |* lsStage
       |* ls


### PR DESCRIPTION
cancelled previous pull request. since we currently have perl script handle the update of smv versions in all MD files, simply added version number to the dead docs links