### PR TITLE
use 'nature' theme for Python API docs (#735)

### DIFF
--- a/admin/conf/sphinx-conf.py
+++ b/admin/conf/sphinx-conf.py
@@ -86,7 +86,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'nature'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Part of #735. This primarily changes the layout and color scheme. We still may need to consider restyling some of the text.