### PR TITLE
#827: getting target from SmvModuleLink now not via a method

### DIFF
--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -633,7 +633,7 @@ def run_module():
 def getFqnOfRequire(ds):
     '''returns fqn of a dataset. If ds is a link, will return fqn of target'''
     if getattr(ds, 'IsSmvModuleLink', None):
-        ds = ds.target()
+        ds = ds.target
     return ds.fqn()
 
 # TODO: rename... should return all information about the module or create if not exists


### PR DESCRIPTION
In order to get the fqn of smv module link target, we were using the SmvModuleLink's .target() method.
.target() is no longer a method, so this code adapts to the given change.