### PR TITLE
I392 read persisted edd

### DIFF
--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -539,9 +539,6 @@ class SmvHiveTable(SmvInput):
         """
         return None
 
-    def doRun(self, validator, known):
-        return self.run(DataFrame(self._smvHiveTable.rdd(False), self.smvApp.sqlContext))
-
 class SmvModule(SmvDataSet):
     """Base class for SmvModules written in Python
     """

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -195,6 +195,14 @@ def discoverSchema(path, n=100000, ca=None):
     """
     SmvApp.getInstance()._jvm.SmvPythonHelper.discoverSchema(path, n, ca or SmvApp.getInstance().defaultCsvWithHeader())
 
+def edd(ds_name):
+    """Print edd report for the result of an SmvDataSet
+
+        Args:
+            ds_name (str): name of an SmvDataSet
+    """
+    _jvmShellCmd().edd(ds_name)
+
 def run_test(test_name):
     """Run a test with the given name without creating new Spark context
 

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -201,7 +201,7 @@ def edd(ds_name):
         Args:
             ds_name (str): name of an SmvDataSet
     """
-    _jvmShellCmd().edd(ds_name)
+    print _jvmShellCmd()._edd(ds_name)
 
 def run_test(test_name):
     """Run a test with the given name without creating new Spark context

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -21,6 +21,8 @@ import dqm.{DQMValidator, ParserLogger, SmvDQM, TerminateParserLogger, FailParse
 import scala.collection.JavaConversions._
 import scala.util.Try
 
+import edd.EddResultFunctions
+
 import org.joda.time._, format._
 
 /** A module's file name part is stackable, e.g. with Using[SmvRunConfig] */
@@ -200,9 +202,9 @@ abstract class SmvDataSet extends FilenamePart {
    * skip the cache.
    * Note: the RDD graph is cached and NOT the data (i.e. rdd.cache is NOT called here)
    */
-  def rdd(forceRun: Boolean = false) = {
+  def rdd(forceRun: Boolean = false, genEdd: Boolean = app.genEdd) = {
     if (forceRun || !app.dfCache.contains(versionedFqn)) {
-      app.dfCache = app.dfCache + (versionedFqn -> computeRDD)
+      app.dfCache = app.dfCache + (versionedFqn -> computeRDD(genEdd))
     }
     app.dfCache(versionedFqn)
   }
@@ -310,12 +312,6 @@ abstract class SmvDataSet extends FilenamePart {
     val n       = counter.value
 
     println(s"${fmt.print(after)} RunTime: ${runTime}, N: ${n}")
-
-    // if EDD flag was specified, generate EDD for the just saved file!
-    // Use the "cached" file that was just saved rather than cause an action
-    // on the input RDD which may cause some expensive computation to re-occur.
-    if (app.genEdd)
-      readFile(path).edd.persistBesideData(path)
   }
 
   private[smv] def readPersistedFile(prefix: String = ""): Try[DataFrame] =
@@ -325,6 +321,12 @@ abstract class SmvDataSet extends FilenamePart {
     Try {
       val json = app.sc.textFile(moduleMetaPath(prefix)).collect.head
       SmvMetadata.fromJson(json)
+    }
+
+  private[smv] def readPersistedEdd(prefix: String = ""): Try[String] =
+    Try {
+      val summary = app.sqlContext.read.json(moduleEddPath(prefix))
+      EddResultFunctions(summary).createReport()
     }
 
   /** Has the result of this data set been persisted? */
@@ -346,6 +348,21 @@ abstract class SmvDataSet extends FilenamePart {
     else
       !isPersisted
   }
+
+  /**
+   * Read EDD from disk if it exists, or create and persist it otherwise
+   */
+  private[smv] def getEdd(): String =
+    readPersistedEdd().getOrElse {
+      // DON'T automatically persist edd. Edd is explicitly persisted on the next
+      // line. This is the simplest way to prevent EDD from being persisted twice.
+      val df = rdd(forceRun = false, genEdd = false)
+      persistEdd(df)
+      readPersistedEdd().get
+    }
+
+  private[smv] def persistEdd(df: DataFrame) =
+    df.edd.persistBesideData(moduleCsvPath())
 
   /**
    * Get the most detailed metadata available without running this module. If
@@ -370,7 +387,7 @@ abstract class SmvDataSet extends FilenamePart {
     metadata
   }
 
-  private[smv] def computeRDD: DataFrame = {
+  private[smv] def computeRDD(genEdd: Boolean): DataFrame = {
     val dqmValidator  = new DQMValidator(dqmWithTypeSpecificPolicy(dqm()))
     val validationSet = new ValidationSet(Seq(dqmValidator), isPersistValidateResult)
 
@@ -393,6 +410,10 @@ abstract class SmvDataSet extends FilenamePart {
               persist(df)
               validationSet.validate(df, true, moduleValidPath()) // has already had action (from persist)
               createMetadata(Some(df)).saveToFile(app.sc, moduleMetaPath())
+              // Generate and persist edd based on result of reading results from disk. Avoids
+              // a possibly expensive action on the result from before persisting.
+              if(genEdd)
+                persistEdd(df)
               readPersistedFile()
             }
           }
@@ -869,7 +890,7 @@ class SmvModuleLink(val outputModule: SmvOutput)
   /**
    * SmvModuleLinks should not cache or validate their data
    */
-  override def computeRDD =
+  override def computeRDD(genEdd: Boolean) =
     throw new SmvRuntimeException("SmvModuleLink computeRDD should never be called")
   override private[smv] def doRun(dqmValidator: DQMValidator) =
     throw new SmvRuntimeException("SmvModuleLink doRun should never be called")
@@ -881,8 +902,8 @@ class SmvModuleLink(val outputModule: SmvOutput)
    * and run the DS, or "not-follow-the-link", which will try to read from the persisted data dir
    * and fail if not found.
    */
-  override def rdd(force: Boolean = false): DataFrame = {
-    // force argument is ignored (SmvModuleLink is rerun anyway)
+  override def rdd(forceRun: Boolean = false, genEdd: Boolean = false): DataFrame = {
+    // forceRun argument is ignored (SmvModuleLink is rerun anyway)
     if (isFollowLink) {
       smvModule.readPublishedData().getOrElse(smvModule.rdd())
     } else {

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -21,7 +21,7 @@ import dqm.{DQMValidator, ParserLogger, SmvDQM, TerminateParserLogger, FailParse
 import scala.collection.JavaConversions._
 import scala.util.Try
 
-import edd.EddResultFunctions
+import edd._
 
 import org.joda.time._, format._
 
@@ -357,9 +357,11 @@ abstract class SmvDataSet extends FilenamePart {
     val unorderedSummary = readPersistedEdd().getOrElse {
       persistEdd(df)
       readPersistedEdd().get
-    }
+      // The persisted df's columns will be ordered arbitrarily, and need to be
+      // reordered to be a valid edd result
+    }.select(EddResult.resultSchema.head, EddResult.resultSchema.tail: _*)
 
-    // Summary rows will not have a reliable order after persisting to HDFS. Need
+    // Summary rows will be ordered arbitrarily after persisting. Need
     // to reorder according to the columns of the df. Original order of tasks will
     // still most likely be lost
     val orderedSummary = df.columns.map { dfColName =>

--- a/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
+++ b/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
@@ -142,7 +142,8 @@ private[smv] class EddResult(
 
 private[smv] object EddResult {
   // Expected schema of EDD results. In some situations (such as reading EDD from
-  // Json) the results may be reordered
+  // Json) the columns of the EDD DataFrame may lose their order and need to be
+  // reset to this order.
   val resultSchema = Seq(
     "colName",
     "taskType",

--- a/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
+++ b/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
@@ -139,23 +139,25 @@ private[smv] class EddResult(
 }
 
 private[smv] object EddResult {
+  // Expected schema of EDD results. In some situations (such as reading EDD from
+  // Json) the results may be reordered
+  val resultSchema = Seq(
+    "colName",
+    "taskType",
+    "taskName",
+    "taskDesc",
+    "valueJSON"
+  )
+
   def apply(r: Row, precision: Int = 5) = {
-    r match {
-      case Row(
-          colName: String,
-          taskType: String,
-          taskName: String,
-          taskDesc: String,
-          valueJSON: String
-          ) =>
-        new EddResult(
-          colName,
-          taskType,
-          taskName,
-          taskDesc,
-          valueJSON
-        )(precision)
-    }
+    val rMap = r.getValuesMap[String](resultSchema)
+    new EddResult(
+      rMap("colName"),
+      rMap("taskType"),
+      rMap("taskName"),
+      rMap("taskDesc"),
+      rMap("valueJSON")
+    )(precision)
   }
 
   private def histSort(hist: Map[Any, Long], histSortByFreq: Boolean) = {

--- a/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
+++ b/src/main/scala/org/tresamigos/smv/edd/EddResult.scala
@@ -41,6 +41,8 @@ import org.json4s.jackson.JsonMethods.{compact, parse}
  * A histogram result represent as Map[Any, Long], where the key could be above 5 types.
  **/
 private[smv] class EddResult(
+    // This parameter list (the expected schema of an Edd result DataFrame) should
+    // track with EddResult.resultSchema
     val colName: String,
     val taskType: String,
     val taskName: String,
@@ -150,14 +152,22 @@ private[smv] object EddResult {
   )
 
   def apply(r: Row, precision: Int = 5) = {
-    val rMap = r.getValuesMap[String](resultSchema)
-    new EddResult(
-      rMap("colName"),
-      rMap("taskType"),
-      rMap("taskName"),
-      rMap("taskDesc"),
-      rMap("valueJSON")
-    )(precision)
+    r match {
+      case Row(
+          colName: String,
+          taskType: String,
+          taskName: String,
+          taskDesc: String,
+          valueJSON: String
+          ) =>
+        new EddResult(
+          colName,
+          taskType,
+          taskName,
+          taskDesc,
+          valueJSON
+        )(precision)
+    }
   }
 
   private def histSort(hist: Map[Any, Long], histSortByFreq: Boolean) = {

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -171,10 +171,11 @@ object ShellCmd {
   def smvExportCsv(name: String, path: String) =
     dsm.inferDS(name).head.exportToCsv(path)
 
-  def edd(name: String): Unit = {
-    val ds = dsm.inferDS(name).head
-    println(ds.getEdd)
-  }
+  def _edd(name: String): String =
+    dsm.inferDS(name).head.getEdd
+
+  def edd(name: String): Unit =
+    println(_edd(name))
 
   /**
    * Resolve SmvDataSet

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -171,6 +171,11 @@ object ShellCmd {
   def smvExportCsv(name: String, path: String) =
     dsm.inferDS(name).head.exportToCsv(path)
 
+  def edd(name: String): Unit = {
+    val ds = dsm.inferDS(name).head
+    println(ds.getEdd)
+  }
+
   /**
    * Resolve SmvDataSet
    *


### PR DESCRIPTION
Addressing #392. It's worth highlighting that the persisted EDD will lose some of its ordering due to partitioning - this was always the case for persisted EDD, but EDD in the shell will also lose its order. If necessary we could avoid this by collecting EDD in memory and exporting as a single CSV without losing the order. For now the EDD rows are sorted by the columns of the df the EDD is derived from.