### PR TITLE
I866 fix stacktraces

### DIFF
--- a/src/main/java/org/tresamigos/smv/IDataSetRepoFactoryPy4J.java
+++ b/src/main/java/org/tresamigos/smv/IDataSetRepoFactoryPy4J.java
@@ -16,7 +16,9 @@ package org.tresamigos.smv;
 
 /**
  * Repository methods used to query and instantiate modules
- * implemented in languages other than Scala.
+ * implemented in languages other than Scala. If you add a method here with
+ * a Python implementation *make sure* to use the @with_stacktrace
+ * decorator to ensure that errors that occur in callbacks don't get eaten.
  */
 public interface IDataSetRepoFactoryPy4J {
 

--- a/src/main/java/org/tresamigos/smv/IDataSetRepoPy4J.java
+++ b/src/main/java/org/tresamigos/smv/IDataSetRepoPy4J.java
@@ -16,7 +16,9 @@ package org.tresamigos.smv;
 
 /**
  * Repository methods used to query and instantiate modules
- * implemented in languages other than Scala.
+ * implemented in languages other than Scala. If you add a method here with
+ * a Python implementation *make sure* to use the @with_stacktrace
+ * decorator to ensure that errors that occur in callbacks don't get eaten.
  */
 public interface IDataSetRepoPy4J {
 	/**

--- a/src/main/java/org/tresamigos/smv/IDataSetRepoPy4J.java
+++ b/src/main/java/org/tresamigos/smv/IDataSetRepoPy4J.java
@@ -22,19 +22,9 @@ package org.tresamigos.smv;
  */
 public interface IDataSetRepoPy4J {
 	/**
-	 * Does the named data set exist?
-	 */
-	boolean hasDataSet(String modUrn);
-
-	/**
 	 * Factory method for ISmvModule
 	 */
 	ISmvModule loadDataSet(String modUrn);
 
 	String[] dataSetsForStage(String modUrn);
-
-	/**
-	 * Get names of all output modules in a given stage
-	 */
-	String[] outputModsForStage(String stageName);
 }

--- a/src/main/java/org/tresamigos/smv/ISmvModule.java
+++ b/src/main/java/org/tresamigos/smv/ISmvModule.java
@@ -23,7 +23,9 @@ import org.tresamigos.smv.dqm.DQMValidator;
 /**
  * Methods that can be implemented by a remote object, such as a
  * Python class, to allow modules written in different languages to
- * work together in an SMV application.
+ * work together in an SMV application. If you add a method here with
+ * a Python implementation *make sure* to use the @with_stacktrace
+ * decorator to ensure that errors that occur in callbacks don't get eaten.
  */
 public interface ISmvModule {
 	/**

--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -17,26 +17,24 @@ import inspect
 
 from error import SmvRuntimeError
 from utils import for_name, smv_copy_array
+from stacktrace_mixin import with_stacktrace, WithStackTrace
 
 """Python implementations of IDataSetRepoPy4J and IDataSetRepoFactoryPy4J interfaces
 """
 
-class DataSetRepoFactory(object):
+class DataSetRepoFactory(WithStackTrace):
     def __init__(self, smvApp):
         self.smvApp = smvApp
-        
+
+    @with_stacktrace
     def createRepo(self):
-        try:
-            return DataSetRepo(self.smvApp)
-        except BaseException as e:
-            traceback.print_exc()
-            raise e
+        return DataSetRepo(self.smvApp)
 
     class Java:
         implements = ['org.tresamigos.smv.IDataSetRepoFactoryPy4J']
 
 
-class DataSetRepo(object):
+class DataSetRepo(WithStackTrace):
     def __init__(self, smvApp):
         self.smvApp = smvApp
         # Remove client modules from sys.modules to force reload of all client
@@ -54,30 +52,21 @@ class DataSetRepo(object):
 
     # Implementation of IDataSetRepoPy4J loadDataSet, which loads the dataset
     # from the most recent source
+    @with_stacktrace
     def loadDataSet(self, fqn):
-        try:
-            ds = for_name(fqn)(self.smvApp)
+        ds = for_name(fqn)(self.smvApp)
 
-            # Python issue https://bugs.python.org/issue1218234
-            # need to invalidate inspect.linecache to make dataset hash work
-            srcfile = inspect.getsourcefile(ds.__class__)
-            if srcfile:
-                inspect.linecache.checkcache(srcfile)
+        # Python issue https://bugs.python.org/issue1218234
+        # need to invalidate inspect.linecache to make dataset hash work
+        srcfile = inspect.getsourcefile(ds.__class__)
+        if srcfile:
+            inspect.linecache.checkcache(srcfile)
 
-            return ds
-        except BaseException as e:
-            traceback.print_exc()
-            raise e
+        return ds
 
+    @with_stacktrace
     def dataSetsForStage(self, stageName):
-        try:
-            return self._moduleUrnsForStage(stageName, lambda obj: obj.IsSmvDataSet)
-        except BaseException as e:
-            traceback.print_exc()
-            raise e
-
-    def outputModsForStage(self, stageName):
-        return self.moduleUrnsForStage(stageName, lambda obj: obj.IsSmvModule and obj.IsSmvOutput)
+        return self._moduleUrnsForStage(stageName, lambda obj: obj.IsSmvDataSet)
 
     def _moduleUrnsForStage(self, stageName, fn):
         # `walk_packages` can generate AttributeError if the system has

--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -24,6 +24,7 @@ from utils import for_name, smv_copy_array
 class DataSetRepoFactory(object):
     def __init__(self, smvApp):
         self.smvApp = smvApp
+        
     def createRepo(self):
         try:
             return DataSetRepo(self.smvApp)

--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -145,54 +145,54 @@ class SmvDataSet(WithStackTrace):
         """
         return "0";
 
+    @with_stacktrace
     def isOutput(self):
         return isinstance(self, SmvOutput)
 
     # Note that the Scala SmvDataSet will combine sourceCodeHash and instanceValHash
     # to compute datasetHash
+    @with_stacktrace
     def sourceCodeHash(self):
         """Hash computed based on the source code of the dataset's class
         """
+        cls = self.__class__
         try:
-            cls = self.__class__
-            try:
-                src = inspect.getsource(cls)
-                src_no_comm = _stripComments(src)
-                # DO NOT use the compiled byte code for the hash computation as
-                # it doesn't change when constant values are changed.  For example,
-                # "a = 5" and "a = 6" compile to same byte code.
-                # co_code = compile(src, inspect.getsourcefile(cls), 'exec').co_code
-                res = _smvhash(src_no_comm)
-            except Exception as err: # `inspect` will raise error for classes defined in the REPL
-                # Instead of handle the case that module defined in REPL, just raise Exception here
-                # res = _smvhash(_disassemble(cls))
-                traceback.print_exc()
-                message = "{0}({1!r})".format(type(err).__name__, err.args)
-                raise Exception(message + "\n" + "SmvDataSet " + self.urn() +" defined in shell can't be persisted")
-
-            # include sourceCodeHash of parent classes
-            for m in inspect.getmro(cls):
-                try:
-                    if m.IsSmvDataSet and m != cls and not m.fqn().startswith("smv."):
-                        res += m(self.smvApp).sourceCodeHash()
-                except: pass
-
-            # if module inherits from SmvRunConfig, then add hash of all config values to module hash
-            if hasattr(self, "_smvGetRunConfigHash"):
-                res += self._smvGetRunConfigHash()
-
-            # ensure python's numeric type can fit in a java.lang.Integer
-            return res & 0x7fffffff
-        except BaseException as e:
+            src = inspect.getsource(cls)
+            src_no_comm = _stripComments(src)
+            # DO NOT use the compiled byte code for the hash computation as
+            # it doesn't change when constant values are changed.  For example,
+            # "a = 5" and "a = 6" compile to same byte code.
+            # co_code = compile(src, inspect.getsourcefile(cls), 'exec').co_code
+            res = _smvhash(src_no_comm)
+        except Exception as err: # `inspect` will raise error for classes defined in the REPL
+            # Instead of handle the case that module defined in REPL, just raise Exception here
+            # res = _smvhash(_disassemble(cls))
             traceback.print_exc()
-            raise e
+            message = "{0}({1!r})".format(type(err).__name__, err.args)
+            raise Exception(message + "\n" + "SmvDataSet " + self.urn() +" defined in shell can't be persisted")
 
+        # include sourceCodeHash of parent classes
+        for m in inspect.getmro(cls):
+            try:
+                if m.IsSmvDataSet and m != cls and not m.fqn().startswith("smv."):
+                    res += m(self.smvApp).sourceCodeHash()
+            except: pass
+
+        # if module inherits from SmvRunConfig, then add hash of all config values to module hash
+        if hasattr(self, "_smvGetRunConfigHash"):
+            res += self._smvGetRunConfigHash()
+
+        # ensure python's numeric type can fit in a java.lang.Integer
+        return res & 0x7fffffff
+
+    @with_stacktrace
     def instanceValHash(self):
         """Hash computed based on instance values of the dataset, such as the timestamp of an input file
         """
         return 0
 
     @classmethod
+    @with_stacktrace
     def fqn(cls):
         """Returns the fully qualified name
         """
@@ -229,44 +229,26 @@ class SmvDataSet(WithStackTrace):
         return None
 
     @abc.abstractmethod
+    @with_stacktrace
     def dsType(self):
         """Return SmvDataSet's type"""
 
+    @with_stacktrace
     def dqmWithTypeSpecificPolicy(self):
-        try:
-            res = self.dqm()
-        except BaseException as err:
-            traceback.print_exc()
-            raise err
+        return self.dqm()
 
-        return res
-
+    @with_stacktrace
     def dependencies(self):
-        # Try/except block is a short-term solution (read: hack) to ensure that
-        # the user gets a full stack trace when SmvDataSet user-defined methods
-        # causes errors
-        try:
-            arr = smv_copy_array(self.smvApp.sc, *[x.urn() for x in self.requiresDS()])
-        except BaseException as err:
-            traceback.print_exc()
-            raise err
-
+        arr = smv_copy_array(self.smvApp.sc, *[x.urn() for x in self.requiresDS()])
         return arr
 
+    @with_stacktrace
     def getDataFrame(self, validator, known):
-        # Try/except block is a short-term solution (read: hack) to ensure that
-        # the user gets a full stack trace when SmvDataSet user-defined methods
-        # causes errors
-        try:
-            df = self.doRun(validator, known)
-            if not isinstance(df, DataFrame):
-                raise SmvRuntimeError(self.fqn() + " produced " + type(df).__name__ + " in place of a DataFrame")
-            else:
-                jdf = df._jdf
-        except BaseException as err:
-            traceback.print_exc()
-            raise err
-
+        df = self.doRun(validator, known)
+        if not isinstance(df, DataFrame):
+            raise SmvRuntimeError(self.fqn() + " produced " + type(df).__name__ + " in place of a DataFrame")
+        else:
+            jdf = df._jdf
         return jdf
 
     class Java:
@@ -303,7 +285,6 @@ class SmvInput(SmvDataSet):
         """derived classes should provide the raw scala proxy input dataset (e.g. SmvCsvFile)
            that is created in their init."""
 
-    @with_stacktrace
     def instanceValHash(self):
         # Defer to Scala target for instanceValHash
         return self.getRawScalaInputDS().instanceValHash()
@@ -318,13 +299,9 @@ class WithParser(object):
     def dqmWithTypeSpecificPolicy(self):
         """for parsers we should get the type specific dqm policy from the
            concrete scala proxy class that is the actual input (e.g. SmvCsvFile)"""
-        try:
-            userDqm = self.dqm()
-            scalaInputDS = self.getRawScalaInputDS()
-            res = scalaInputDS.dqmWithTypeSpecificPolicy(userDqm)
-        except BaseException as err:
-            traceback.print_exc()
-            raise err
+        userDqm = self.dqm()
+        scalaInputDS = self.getRawScalaInputDS()
+        res = scalaInputDS.dqmWithTypeSpecificPolicy(userDqm)
 
         return res
 
@@ -490,6 +467,7 @@ class SmvJdbcTable(SmvInput):
         return self._smvJdbcTable.description()
 
     @abc.abstractproperty
+    @with_stacktrace
     def tableName(self):
         """User-specified name for the table to extract input from
 
@@ -519,6 +497,7 @@ class SmvHiveTable(SmvInput):
         return self._smvHiveTable
 
     @abc.abstractproperty
+    @with_stacktrace
     def tableName(self):
         """User-specified name Hive hive table to extract input from
 


### PR DESCRIPTION
Addressing #866. 

Also, after reflecting on this design a bit, I think there is significant risk of printing redundant stack traces if code changes significantly in the future. Particularly, the current design doesn't account for  one @with_stacktrace method calling another, or if a @with_stacktrace method has an error when called by the Python driver (rather than as a callback). Seems low priority to fix these problems though.