### PR TITLE
Add travis caching to speed up build times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ metastore_db/
 
 .sync-config.cson
 *.pyc
+
+.bashrc
+.ivy2
+.jupyter/
+.sbt/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
     - $HOME/.pip-cache/
+    - $HOME/.pyenv/cache
 install:
   - tools/spark-install ./spark
   - export PATH="$PATH:$(pwd)/spark/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+    - $HOME/.pip-cache/
 install:
   - tools/spark-install ./spark
   - export PATH="$PATH:$(pwd)/spark/bin"
   - pyenv install 2.7.10
   - pyenv install 3.5.2
   - pyenv local 3.5.2 2.7.10
-  - pip install tox
+  - pip install --cache-dir $HOME/.pip-cache tox
 script:
   - sbt ++2.10.4 assembly
   - sbt ++2.10.4 publish-local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
+# Enable caching
+# http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#Caching
+# https://docs.travis-ci.com/user/caching/
 sudo: required
 dist: trusty
 language: python
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
 install:
   - tools/spark-install ./spark
   - export PATH="$PATH:$(pwd)/spark/bin"


### PR DESCRIPTION
Stash the ivy repo between builds to speed up build times. 

I am not 100% sure this is going to work as some of the documentation seems to indicate that we need to be on the the Travis "container-based infrastructure", and I am not 100% sure that happens since we run Travis with the `sudo: required` option. 

Docs:
* http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#Caching
* https://docs.travis-ci.com/user/caching/
* Example from Spark [source](https://github.com/apache/spark/blob/master/.travis.yml)