### PR TITLE
remove 'org' from name of integration test modules

### DIFF
--- a/src/test/scripts/run-integration-test.sh
+++ b/src/test/scripts/run-integration-test.sh
@@ -34,7 +34,7 @@ test7 \
 
 NEW_MODULE_STAGES="$NEW_PYTHON_MODULE_STAGES $NEW_SCALA_MODULE_STAGES"
 
-HASH_TEST_MOD="org.tresamigos.smvtest.hashtest.modules.M"
+HASH_TEST_MOD="integration.test.hashtest.modules.M"
 
 echo "--------- GENERATE INTEGRATION APP -------------"
 ../../tools/smv-init -test ${I_APP_NAME}
@@ -54,7 +54,7 @@ echo "--------- RUN INTEGRATION APP -------------"
 echo "--------- CHECK INTEGRATION APP OUTPUT -------------"
 for stage in $NEW_SCALA_MODULE_STAGES; do
   TEST_INPUT=$(< data/input/$stage/table.csv)
-  TEST_OUTPUT=$(cat data/output/org.tresamigos.smvtest.$stage.M2_*.csv/part*)
+  TEST_OUTPUT=$(cat data/output/integration.test.$stage.M2_*.csv/part*)
   if [[ $TEST_INPUT != $TEST_OUTPUT ]]; then
     echo "Test failure: $stage"
     echo "Expected output:"
@@ -67,7 +67,7 @@ done
 
 for stage in $NEW_PYTHON_MODULE_STAGES; do
   TEST_INPUT=$(< data/input/$stage/table.csv)
-  TEST_OUTPUT=$(cat data/output/org.tresamigos.smvtest.$stage.modules.M2_*.csv/part*)
+  TEST_OUTPUT=$(cat data/output/integration.test.$stage.modules.M2_*.csv/part*)
   if [[ $TEST_INPUT != $TEST_OUTPUT ]]; then
     echo "Test failure: $stage"
     echo "Expected output:"

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -54,7 +54,7 @@ PROJ_CLASS=""
 
 # proj class hardcoded for smv integration tests
 if [ "$PROJ_TYPE" = "test" ]; then
-  PROJ_CLASS="org.tresamigos.smvtest"
+  PROJ_CLASS="integration.test"
 fi
 
 function extract_group_artifact_ids()

--- a/tools/templates/test/conf/smv-app-conf.props
+++ b/tools/templates/test/conf/smv-app-conf.props
@@ -2,16 +2,16 @@
 smv.appName = Example App
 
 # stage definitions
-smv.stages = org.tresamigos.smvtest.test1, \
-             org.tresamigos.smvtest.test2, \
-             org.tresamigos.smvtest.test3, \
-             org.tresamigos.smvtest.test3_1, \
-             org.tresamigos.smvtest.test4, \
-             org.tresamigos.smvtest.test4_1, \
-             org.tresamigos.smvtest.test5, \
-             org.tresamigos.smvtest.test6, \
-             org.tresamigos.smvtest.test7, \
-             org.tresamigos.smvtest.test7_1, \
-             org.tresamigos.smvtest.test8, \
-             org.tresamigos.smvtest.test8_1, \
-             org.tresamigos.smvtest.hashtest
+smv.stages = integration.test.test1, \
+             integration.test.test2, \
+             integration.test.test3, \
+             integration.test.test3_1, \
+             integration.test.test4, \
+             integration.test.test4_1, \
+             integration.test.test5, \
+             integration.test.test6, \
+             integration.test.test7, \
+             integration.test.test7_1, \
+             integration.test.test8, \
+             integration.test.test8_1, \
+             integration.test.hashtest

--- a/tools/templates/test/src/main/python/hashtest/modules.py
+++ b/tools/templates/test/src/main/python/hashtest/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.hashtest import input
+from integration.test.hashtest import input
 
 class M(SmvModule, SmvOutput):
     def requiresDS(self):

--- a/tools/templates/test/src/main/python/test2/modules.py
+++ b/tools/templates/test/src/main/python/test2/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.test2 import input
+from integration.test.test2 import input
 
 class M1(SmvModule):
     def requiresDS(self):

--- a/tools/templates/test/src/main/python/test4/input.py
+++ b/tools/templates/test/src/main/python/test4/input.py
@@ -2,7 +2,7 @@ from smv import *
 import traceback
 
 try:
-    from org.tresamigos.smvtest.test4_1.modules import M1
+    from integration.test.test4_1.modules import M1
 
     M1Link = SmvModuleLink(M1)
 

--- a/tools/templates/test/src/main/python/test4/modules.py
+++ b/tools/templates/test/src/main/python/test4/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.test4 import input
+from integration.test.test4 import input
 
 class M2(SmvModule, SmvOutput):
     def requiresDS(self):

--- a/tools/templates/test/src/main/python/test4_1/modules.py
+++ b/tools/templates/test/src/main/python/test4_1/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.test4_1 import input
+from integration.test.test4_1 import input
 
 class M1(SmvModule, SmvOutput):
     def requiresDS(self):

--- a/tools/templates/test/src/main/python/test5/modules.py
+++ b/tools/templates/test/src/main/python/test5/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.test5 import input
+from integration.test.test5 import input
 
 class M1(SmvModule, SmvOutput):
     def requiresDS(self):

--- a/tools/templates/test/src/main/python/test6/modules.py
+++ b/tools/templates/test/src/main/python/test6/modules.py
@@ -2,7 +2,7 @@ from smv import *
 
 class M2(SmvModule, SmvOutput):
     def requiresDS(self):
-        return [ SmvExtDataSet("org.tresamigos.smvtest.test6.M1") ]
+        return [ SmvExtDataSet("integration.test.test6.M1") ]
 
     def run(self, i):
-        return i[ SmvExtDataSet("org.tresamigos.smvtest.test6.M1") ]
+        return i[ SmvExtDataSet("integration.test.test6.M1") ]

--- a/tools/templates/test/src/main/python/test7/modules.py
+++ b/tools/templates/test/src/main/python/test7/modules.py
@@ -2,7 +2,7 @@ from smv import *
 
 class M2(SmvModule, SmvOutput):
     def requiresDS(self):
-        return [ SmvExtModuleLink("org.tresamigos.smvtest.test7_1.M1") ]
+        return [ SmvExtModuleLink("integration.test.test7_1.M1") ]
 
     def run(self, i):
-        return i[ SmvExtModuleLink("org.tresamigos.smvtest.test7_1.M1") ]
+        return i[ SmvExtModuleLink("integration.test.test7_1.M1") ]

--- a/tools/templates/test/src/main/python/test8_1/modules.py
+++ b/tools/templates/test/src/main/python/test8_1/modules.py
@@ -1,6 +1,6 @@
 from smv import *
 
-from org.tresamigos.smvtest.test8_1 import input
+from integration.test.test8_1 import input
 
 class M1(SmvModule, SmvOutput):
     def requiresDS(self):

--- a/tools/templates/test/src/main/scala/test1/input/input.scala
+++ b/tools/templates/test/src/main/scala/test1/input/input.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test1
+package integration.test.test1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test1/modules.scala
+++ b/tools/templates/test/src/main/scala/test1/modules.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test1
+package integration.test.test1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test3/input/input.scala
+++ b/tools/templates/test/src/main/scala/test3/input/input.scala
@@ -1,5 +1,5 @@
-package org.tresamigos.smvtest.test3
+package integration.test.test3
 
 import org.tresamigos.smv._
 
-object M1Link extends SmvModuleLink(org.tresamigos.smvtest.test3_1.M1)
+object M1Link extends SmvModuleLink(integration.test.test3_1.M1)

--- a/tools/templates/test/src/main/scala/test3/modules.scala
+++ b/tools/templates/test/src/main/scala/test3/modules.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test3
+package integration.test.test3
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test3_1/input/input.scala
+++ b/tools/templates/test/src/main/scala/test3_1/input/input.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test3_1
+package integration.test.test3_1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test3_1/modules.scala
+++ b/tools/templates/test/src/main/scala/test3_1/modules.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test3_1
+package integration.test.test3_1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test5/modules.scala
+++ b/tools/templates/test/src/main/scala/test5/modules.scala
@@ -1,11 +1,11 @@
-package org.tresamigos.smvtest.test5
+package integration.test.test5
 
 import org.tresamigos.smv._
 
 object M2 extends SmvModule("") with SmvOutput {
-  override def requiresDS = Seq(SmvExtModule("org.tresamigos.smvtest.test5.modules.M1"))
+  override def requiresDS = Seq(SmvExtModule("integration.test.test5.modules.M1"))
 
   override def run(i: runParams) = {
-    i(SmvExtModule("org.tresamigos.smvtest.test5.modules.M1"))
+    i(SmvExtModule("integration.test.test5.modules.M1"))
   }
 }

--- a/tools/templates/test/src/main/scala/test6/input/input.scala
+++ b/tools/templates/test/src/main/scala/test6/input/input.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test6
+package integration.test.test6
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test6/modules.scala
+++ b/tools/templates/test/src/main/scala/test6/modules.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test6
+package integration.test.test6
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test7_1/input/input.scala
+++ b/tools/templates/test/src/main/scala/test7_1/input/input.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test7_1
+package integration.test.test7_1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test7_1/modules.scala
+++ b/tools/templates/test/src/main/scala/test7_1/modules.scala
@@ -1,4 +1,4 @@
-package org.tresamigos.smvtest.test7_1
+package integration.test.test7_1
 
 import org.tresamigos.smv._
 

--- a/tools/templates/test/src/main/scala/test8/modules.scala
+++ b/tools/templates/test/src/main/scala/test8/modules.scala
@@ -1,11 +1,11 @@
-package org.tresamigos.smvtest.test8
+package integration.test.test8
 
 import org.tresamigos.smv._
 
 object M2 extends SmvModule("") with SmvOutput {
-  override def requiresDS = Seq(SmvExtModuleLink("org.tresamigos.smvtest.test8_1.modules.M1"))
+  override def requiresDS = Seq(SmvExtModuleLink("integration.test.test8_1.modules.M1"))
 
   override def run(i: runParams) = {
-    i(SmvExtModuleLink("org.tresamigos.smvtest.test8_1.modules.M1"))
+    i(SmvExtModuleLink("integration.test.test8_1.modules.M1"))
   }
 }


### PR DESCRIPTION
Addressing #901. May only be needed for Spark 2.1 with Python 3.5 but the tests should be kept in sync across branches where possible. Can be merged into 2.1 after PR is merged.