### PR TITLE
I991 purge output show deleted

### DIFF
--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -90,13 +90,12 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   /** remove all non-current files in the output directory */
   private[smv] def purgeOldOutputFiles() = {
     if (smvConfig.cmdLine.purgeOldOutput()) {
-      val results = SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir()).groupBy(_._2)
-      results foreach {
-        case (k, fns) =>
-          if (k)
-            fns foreach { deleted => println(s"... Deleted ${deleted._1}") }
-          else
-            fns foreach { failed => println(s"... Unabled to delete ${failed._1}") }
+      SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir()) foreach {
+        case (fn, success) =>
+          println(
+            if (success) s"... Deleted ${fn}"
+            else s"... Unabled to delete ${fn}"
+          )
       }
     }
   }

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -91,8 +91,13 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   private[smv] def purgeOldOutputFiles() = {
     if (smvConfig.cmdLine.purgeOldOutput()) {
       val results = SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir()).groupBy(_._2)
-      results(true) foreach { deleted => println(s"... Deleted ${deleted._1}") }
-      results(false) foreach { failed => println(s"... Unabled to delete ${failed._1}") }
+      results foreach {
+        case (k, fns) =>
+          if (k)
+            fns foreach { deleted => println(s"... Deleted ${deleted._1}") }
+          else
+            fns foreach { failed => println(s"... Unabled to delete ${failed._1}") }
+      }
     }
   }
 

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -89,8 +89,11 @@ class SmvApp(private val cmdLineArgs: Seq[String],
 
   /** remove all non-current files in the output directory */
   private[smv] def purgeOldOutputFiles() = {
-    if (smvConfig.cmdLine.purgeOldOutput())
-      SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir())
+    if (smvConfig.cmdLine.purgeOldOutput()) {
+      val results = SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir()).groupBy(_._2)
+      results(true) foreach { deleted => println(s"... Deleted ${deleted._1}") }
+      results(false) foreach { failed => println(s"... Unabled to delete ${failed._1}") }
+    }
   }
 
   /**

--- a/src/main/scala/org/tresamigos/smv/SmvHDFS.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvHDFS.scala
@@ -108,14 +108,15 @@ private[smv] object SmvHDFS {
   /**
    * Purge the contents of the given directory that are not in the keep list.
    * This is a shallow purge, subdirs in dirName are not inspected.
+   *
    * @param dirName directory to purge.
    * @param keepFiles base names of files in above directory to keep
+   * @return a sequence of to-be-deleted filenames and whether the deletion is successful
    */
-  def purgeDirectory(dirName: String, keepFiles: Seq[String]) = {
-    val dirFiles = dirList(dirName)
-
-    (dirFiles.toSet -- keepFiles).foreach { f =>
-      deleteFile(s"${dirName}/${f}")
-    }
-  }
+  def purgeDirectory(dirName: String, keepFiles: Seq[String]): Seq[(String, Boolean)] =
+    for {
+      file <- (dirList(dirName).toSet -- keepFiles).toSeq.sorted
+      filename = s"${dirName}/${file}"
+      r = deleteFile(filename)
+    } yield (filename, r)
 }


### PR DESCRIPTION
This implementation separates the printing of the purge results from purging itself.

If you'd like to have the logging done directly in `SmvHDFS`, we can do that, too, which would simplify the change.