### PR TITLE
refact: newly-registered repo factory should be searched first

### DIFF
--- a/src/main/scala/org/tresamigos/smv/DataSetMgr.scala
+++ b/src/main/scala/org/tresamigos/smv/DataSetMgr.scala
@@ -29,7 +29,8 @@ class DataSetMgr(smvConfig: SmvConfig) {
   private var allStageNames                            = smvConfig.stageNames
 
   def register(newRepoFactory: DataSetRepoFactory): Unit = {
-    dsRepoFactories = dsRepoFactories :+ newRepoFactory
+    // more recently registered repo factories are searched first
+    dsRepoFactories = newRepoFactory +: dsRepoFactories
   }
 
   /**


### PR DESCRIPTION
To resolve situations where modules may be found by multiple dataset repositories, we establish that the repositories should be searched in a stack fashion -- more recently registered first.