### PR TITLE
#1014: rm SPARK_HOME and add support for spark-submit/pyspark override

### DIFF
--- a/docs/user/run_app.md
+++ b/docs/user/run_app.md
@@ -212,6 +212,17 @@ One of the options below must be specified.
 
 </table>
 
+### Spark commands override
+Users are able to override the name of the spark commands used to launch batch jobs and shell.  The two environment variables `SMV_SPARK_SUBMIT_CMD` and `SMV_PYSPARK_CMD` can be used to override the `spark-submit` and `pyspark` commands respectively.
+For example, on a cloudera system with both spark 1.6 and spark 2.2, user can set the following in their shell profile:
+```bash
+# user's .bash_profile
+export SMV_SPARK_SUBMIT_CMD="spark2-submit"
+export SMV_PYSPARK_CMD="pyspark2"
+```
+
+The above would ensure that SMV users the spark 2.2 version on the system.
+
 ### Examples
 Run modules `M1` and `M2` and all its dependencies.  Note the use of the module FQN.
 ```shell

--- a/docs/user/run_app.md
+++ b/docs/user/run_app.md
@@ -141,7 +141,7 @@ publish the specified modules to the local file system
 
 <tr>
 <td>--spark-home</td>
-<td>SPARK_HOME environment variable or location of spark-submit</td>
+<td>location of spark-submit</td>
 <td>Location where SMV should find Spark installation.
 </td>
 </tr>

--- a/tools/_pyenv.sh
+++ b/tools/_pyenv.sh
@@ -14,5 +14,5 @@ export PYTHONDONTWRITEBYTECODE=1
 export SPARK_PRINT_LAUNCH_COMMAND=1
 
 function run_pyspark_with () {
-  "$SPARK_HOME/bin/spark-submit" "${SPARK_ARGS[@]}" --jars "$APP_JAR,$EXTRA_JARS" --driver-class-path "$APP_JAR" $1 "${SMV_ARGS[@]}"
+  "${SMV_SPARK_SUBMIT_FULLPATH}" "${SPARK_ARGS[@]}" --jars "$APP_JAR,$EXTRA_JARS" --driver-class-path "$APP_JAR" $1 "${SMV_ARGS[@]}"
 }

--- a/tools/smv-pyshell
+++ b/tools/smv-pyshell
@@ -22,7 +22,7 @@ export PYTHONSTARTUP="smv_pyshell_init.py"
 # https://issues.apache.org/jira/browse/SPARK-5185) that does not add
 # the jar file to the driver's classpath, so we need to add the jars
 # to the --driver-class-path command-line option
-"$SPARK_HOME/bin/pyspark"  "${SPARK_ARGS[@]}" --jars "$APP_JAR,$EXTRA_JARS" --driver-class-path "${APP_JAR}"
+"${SMV_PYSPARK_FULLPATH}"  "${SPARK_ARGS[@]}" --jars "$APP_JAR,$EXTRA_JARS" --driver-class-path "${APP_JAR}"
 
 # Reset PYTHONSTARTUP
 export PYTHONSTARTUP=$OLD_PYTHONSTARTUP

--- a/tools/smv-r
+++ b/tools/smv-r
@@ -8,7 +8,10 @@ export SMV_HOME="$(cd "${SMV_TOOLS}/.."; pwd)"
 export SMV_APP_JAR="$SMV_APP_HOME/$APP_JAR"
 export R_PROFILE="${SMV_TOOLS}/conf/sparkR_init.r"
 
-set_spark_home
+# TODO: the r module "sparkR_init.r" expects SPARK_HOME to be set to add the
+# lib path for all the spark R modules.  Need to fix this once we need to
+# support R once again.
+set_smv_spark_paths
 
 if type rstudio &> /dev/null; then
   R_CMD="rstudio"


### PR DESCRIPTION
Fixes #1014 and #1015.
For clients with newer versions of Cloudera, SMV fails on two counts:
* setting SPARK_HOME internally in SMV caused Cloudera to fail to run.
* Cloudera used `spark-submit2` and `pyspark2` for the executable names for spark 2.2