### PR TITLE
refact: helper method names should not start with 'test'

### DIFF
--- a/src/main/python/test_support/smvbasetest.py
+++ b/src/main/python/test_support/smvbasetest.py
@@ -48,7 +48,7 @@ class SmvBaseTest(unittest.TestCase):
         # The original SmvApp (if any) will be restored when the test is torn down
         cls.smvApp = SmvApp.createInstance(args, cls.sparkContext, cls.sqlContext)
 
-        sys.path.append(cls.testResourceDir())
+        sys.path.append(cls.resourceTestDir())
 
         cls.mkTmpTestDir()
 
@@ -59,7 +59,7 @@ class SmvBaseTest(unittest.TestCase):
         from smv.smvapp import SmvApp
         # Restore SmvApp singleton
         SmvApp.setInstance(TestConfig.originalSmvApp())
-        sys.path.remove(cls.testResourceDir())
+        sys.path.remove(cls.resourceTestDir())
 
     def setUp(self):
         """Patch for Python 2.6 without using unittest
@@ -97,7 +97,7 @@ class SmvBaseTest(unittest.TestCase):
         self.assertEqual(sort_collect(expected), sort_collect(result))
 
     @classmethod
-    def testResourceDir(cls):
+    def resourceTestDir(cls):
         """Directory where resources (like modules to run) for this test are expected."""
         return cls.TestSrcDir + "/" + cls.__module__
 

--- a/src/test/python/testDataSetRepo.py
+++ b/src/test/python/testDataSetRepo.py
@@ -24,11 +24,11 @@ class DataSetRepoTest(SmvBaseTest):
 
     @classmethod
     def before_dir(cls):
-        return cls.testResourceDir() + "/before"
+        return cls.resourceTestDir() + "/before"
 
     @classmethod
     def after_dir(cls):
-        return cls.testResourceDir() + "/after"
+        return cls.resourceTestDir() + "/after"
 
     def build_new_repo(self): return DataSetRepo(self.smvApp)
 

--- a/src/test/python/testHdfsConn.py
+++ b/src/test/python/testHdfsConn.py
@@ -25,7 +25,7 @@ class HdfsBridgeTest(SmvBaseTest):
         """Helper method to copy a test resource to hdfs"""
 
         # invoke the hdfs copy method
-        srcpath = os.path.join(self.testResourceDir(), fn)
+        srcpath = os.path.join(self.resourceTestDir(), fn)
         destpath = os.path.join(self.tmpTestDir(), fn)
         with open(srcpath, 'rb') as f: self.smvApp.copyToHdfs(f, destpath)
 

--- a/src/test/python/testModuleHash.py
+++ b/src/test/python/testModuleHash.py
@@ -24,11 +24,11 @@ class ModuleHashTest(SmvBaseTest):
 
     @classmethod
     def before_dir(cls):
-        return cls.testResourceDir() + "/before"
+        return cls.resourceTestDir() + "/before"
 
     @classmethod
     def after_dir(cls):
-        return cls.testResourceDir() + "/after"
+        return cls.resourceTestDir() + "/after"
 
     class Resource(object):
         def __init__(self, smvApp, path, fqn):


### PR DESCRIPTION
Noticed this when I was running individual python tests.

The helper method `SmvBaseTest.testResourceDir` was picked up and run as separate tests.

This refactor renames the method so it won't be run.
And our python test count should now be correct.