### PR TITLE
I1050 dynamic runtime config

### DIFF
--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -187,8 +187,8 @@ def getDatasetInstance(fqn):
     '''returns dataset object given a fqn'''
     return DataSetRepoFactory(SmvApp.getInstance()).createRepo().loadDataSet(fqn)
 
-def runModule(fqn):
-    '''runs module of given fqn'''
+def runModule(fqn, run_config=None):
+    '''runs module of given fqn and runtime configuration'''
     return SmvApp.getInstance().runModule("mod:{}".format(fqn))
 
 def getMetadataJson(fqn):
@@ -200,14 +200,23 @@ def getMetadataJson(fqn):
 @app.route("/api/run_module", methods = ['POST'])
 def run_module():
     '''
-    body: fqn = 'xxx' (fqn)
-    function: run the module
+    body:
+        'fqn': module fqn
+        'run_config': runtime configuration(optional)
+    function: run the module of given fqn and runtime configuration
     '''
     try:
         module_fqn = request.form['fqn'].encode("utf-8")
     except:
         raise err_res('MODULE_NOT_PROVIDED_ERR')
-    return ok_res(str(runModule(module_fqn)))
+    try:
+        encoded_run_config = None
+        run_config = request.form['run_config']
+        if run_config is not None:
+            encoded_run_config = run_config.encode("utf-8")
+    except:
+        raise err_res('MODULE_RUN_CONFIGURATION_ERR')
+    return ok_res(str(runModule(module_fqn, encoded_run_config)))
 
 @app.route("/api/get_graph_json", methods = ['POST'])
 def get_graph_json():

--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -189,7 +189,7 @@ def getDatasetInstance(fqn):
 
 def runModule(fqn, run_config=None):
     '''runs module of given fqn and runtime configuration'''
-    return SmvApp.getInstance().runModule("mod:{}".format(fqn))
+    return SmvApp.getInstance().runModule(name="mod:{}".format(fqn), runConfig=run_config)
 
 def getMetadataJson(fqn):
     '''returns metadata given a fqn'''

--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -189,7 +189,7 @@ def getDatasetInstance(fqn):
 
 def runModule(fqn, run_config=None):
     '''runs module of given fqn and runtime configuration'''
-    return SmvApp.getInstance().runModule(name="mod:{}".format(fqn), runConfig=run_config)
+    return SmvApp.getInstance().runModule("mod:{}".format(fqn), runConfig=run_config)
 
 def getMetadataJson(fqn):
     '''returns metadata given a fqn'''

--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -205,13 +205,14 @@ def run_module():
         'run_config': runtime configuration(optional)
     function: run the module of given fqn and runtime configuration
     '''
+    json = request.get_json()
     try:
-        module_fqn = request.form['fqn'].encode("utf-8")
+        module_fqn = json['fqn'].encode("utf-8")
     except:
         raise err_res('MODULE_NOT_PROVIDED_ERR')
     try:
         encoded_run_config = None
-        run_config = request.form['run_config']
+        run_config = json['run_config']
         if run_config is not None:
             encoded_run_config = run_config.encode("utf-8")
     except:

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -176,10 +176,10 @@ class SmvApp(object):
         df = self.runModule(urn, forceRun, version)
         return ds.df2result(df)
 
-    def runModule(self, urn, forceRun = False, version = None):
+    def runModule(self, urn, forceRun = False, version = None, runConfig = None):
         """Runs either a Scala or a Python SmvModule by its Fully Qualified Name(fqn)
         """
-        jdf = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version))
+        jdf = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version), runConfig)
         return DataFrame(jdf, self.sqlContext)
 
     def getMetadataJson(self, urn):

--- a/src/main/python/test_support/testconfig.py
+++ b/src/main/python/test_support/testconfig.py
@@ -13,7 +13,7 @@
 import sys
 
 from pyspark import SparkContext
-from pyspark.sql import HiveContext
+from pyspark.sql import HiveContext, SQLContext
 
 from smv.smvapp import SmvApp
 
@@ -47,7 +47,7 @@ class TestConfig(object):
     @classmethod
     def sqlContext(cls):
         if not hasattr(cls, 'sqlc'):
-            cls.sqlc = HiveContext(cls.sparkContext())
+            cls.sqlc = SQLContext(cls.sparkContext())
         return cls.sqlc
 
     # smv args specified via command line

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -314,7 +314,7 @@ class SmvApp(private val cmdLineArgs: Seq[String],
 
   /**
    * set dynamic runtime configuration.
-   * this should be set before run operation.
+   * this should be set before run dataset.
    */
   private def setDynamicRunConfig(runConfig: Map[String, String]) = {
     smvConfig.dynamicRunConfig = runConfig
@@ -345,7 +345,8 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   /** Run a module by its fully qualified name in its respective language environment
    *  If force argument is true, any existing persisted results will be deleted
    *  and the module's DataFrame cache will be ignored, forcing the module to run again.
-   * If a version is specified, try to read the module from the published data for the given version
+   *  If a version is specified, try to read the module from the published data for the given version.
+   *  If dynamic runtime configuration is specified, run the module with the configuration provided.
    */
   def runModule(urn: URN,
                 forceRun: Boolean = false,

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -239,14 +239,17 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
         throw new SmvRuntimeException("JDBC url not specified in SMV config")
     }
 
+  // ---------- Dynamic Run Config Parameters key/values ----------
+  var dynamicRunConfig: Map[String, String] = Map()
+
   /** The FQN of configuration object for a particular run.  See github issue #319 */
   val runConfObj: Option[String] = cmdLine.runConfObj.get.orElse(mergedProps.get(RunConfObjKey))
 
   // ---------- User Run Config Parameters key/values ----------
-  val runConfigKeys: Seq[String] = splitProp("smv.config.keys")
+  lazy val runConfigKeys: Seq[String] = splitProp("smv.config.keys") ++ dynamicRunConfig.keySet
 
   /** Get user run config parameter as a string. */
-  def getRunConfig(key: String): String = mergedProps("smv.config." + key).trim
+  def getRunConfig(key: String): String = dynamicRunConfig.getOrElse(key, mergedProps("smv.config." + key).trim)
 
   /** compute hash of all key values defined in the app. */
   def getRunConfigHash(): Int = runConfigKeys.map(getRunConfig(_)).mkString(":").hashCode()

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -246,13 +246,14 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
   val runConfObj: Option[String] = cmdLine.runConfObj.get.orElse(mergedProps.get(RunConfObjKey))
 
   // ---------- User Run Config Parameters key/values ----------
-  lazy val runConfigKeys: Seq[String] = splitProp("smv.config.keys") ++ dynamicRunConfig.keySet
-
   /** Get user run config parameter as a string. */
   def getRunConfig(key: String): String = dynamicRunConfig.getOrElse(key, mergedProps("smv.config." + key).trim)
 
+  /** Get all run config keys. */
+  def getRunConfigKeys(): Seq[String] = splitProp("smv.config.keys") ++ dynamicRunConfig.keySet
+
   /** compute hash of all key values defined in the app. */
-  def getRunConfigHash(): Int = runConfigKeys.map(getRunConfig(_)).mkString(":").hashCode()
+  def getRunConfigHash(): Int = getRunConfigKeys().map(getRunConfig(_)).mkString(":").hashCode()
 
   // ---------- hierarchy of data / input / output directories
 

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -240,7 +240,7 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
     }
 
   // ---------- Dynamic Run Config Parameters key/values ----------
-  var dynamicRunConfig: Map[String, String] = Map()
+  var dynamicRunConfig: Map[String, String] = Map.empty
 
   /** The FQN of configuration object for a particular run.  See github issue #319 */
   val runConfObj: Option[String] = cmdLine.runConfObj.get.orElse(mergedProps.get(RunConfObjKey))

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -252,8 +252,11 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   def urn2fqn(modUrn: String): String = org.tresamigos.smv.urn2fqn(modUrn)
 
   /** Runs an SmvModule written in either Python or Scala */
-  def runModule(urn: String, forceRun: Boolean, version: Option[String]): DataFrame =
-    j_smvApp.runModule(URN(urn), forceRun, version)
+  def runModule(urn: String,
+                forceRun: Boolean,
+                version: Option[String],
+                runConfig: Map[String, String] = Map.empty): DataFrame =
+    j_smvApp.runModule(URN(urn), forceRun, version, runConfig)
 
   def copyToHdfs(in: IAnyInputStream, dest: String): Unit =
     SmvHDFS.writeToFile(in, dest)

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -255,8 +255,11 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   def runModule(urn: String,
                 forceRun: Boolean,
                 version: Option[String],
-                runConfig: Map[String, String] = Map.empty): DataFrame =
-    j_smvApp.runModule(URN(urn), forceRun, version, runConfig)
+                runConfig: java.util.Map[String, String]): DataFrame = {
+      var dynamicRunConfig: Map[String, String] = if (null == runConfig) Map.empty else mapAsScalaMap(runConfig).toMap
+
+      j_smvApp.runModule(URN(urn), forceRun, version, dynamicRunConfig)
+    }
 
   def copyToHdfs(in: IAnyInputStream, dest: String): Unit =
     SmvHDFS.writeToFile(in, dest)

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -45,7 +45,7 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
 
     def test_run_module_with_dynamic_run_config(self):
         self.smvApp.j_smvApp.run()
-        a = self.smvApp.runModule(self.modUrn, {'src': 'dynamic_a'})
+        a = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_a'})
         self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
-        b = self.smvApp.runModule(self.modUrn, {'src': 'dynamic_b'})
+        b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})
         self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -45,7 +45,7 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
 
     def test_run_module_with_dynamic_run_config(self):
         self.smvApp.j_smvApp.run()
-        a = self.smvApp.runModule(self.modUrn, {src: 'dynamic_a'})
+        a = self.smvApp.runModule(self.modUrn, {'src': 'dynamic_a'})
         self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
-        b = self.smvApp.runModule(self.modUrn, {src: 'dynamic_b'})
+        b = self.smvApp.runModule(self.modUrn, {'src': 'dynamic_b'})
         self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -14,20 +14,6 @@
 from test_support.smvbasetest import SmvBaseTest
 from smv import SmvApp
 
-class RunModuleWithoutRunConfigTest(SmvBaseTest):
-    modUrn = 'mod:stage.modules.A'
-
-    @classmethod
-    def smvAppInitArgs(cls):
-        return ['--smv-props', 'smv.stages=stage',
-                '-m', "modules.A"]
-
-    def test_run_module_without_run_config(self):
-        self.smvApp.j_smvApp.run()
-        res = self.smvApp.runModule(self.modUrn)
-        expected = self.createDF('src:String', '')
-        self.should_be_same(res, expected)
-
 class RunModuleWithRunConfigTest(SmvBaseTest):
     modUrn = 'mod:stage.modules.A'
 
@@ -49,3 +35,6 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
         self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
         b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})
         self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))
+
+        c = self.smvApp.runModule(self.modUrn)
+        self.should_be_same(c, self.createDF('src:String', 'cmd'))

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -1,0 +1,51 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_support.smvbasetest import SmvBaseTest
+from smv import SmvApp
+
+class RunModuleWithoutRunConfigTest(SmvBaseTest):
+    modUrn = 'mod:stage.modules.A'
+
+    @classmethod
+    def smvAppInitArgs(cls):
+        return ['--smv-props', 'smv.stages=stage',
+                '-m', "modules.A"]
+
+    def test_run_module_without_run_config(self):
+        self.smvApp.j_smvApp.run()
+        res = self.smvApp.runModule(self.modUrn)
+        expected = self.createDF('src:String', '')
+        self.should_be_same(res, expected)
+
+class RunModuleWithRunConfigTest(SmvBaseTest):
+    modUrn = 'mod:stage.modules.A'
+
+    @classmethod
+    def smvAppInitArgs(cls):
+        return ['--smv-props', 'smv.stages=stage',
+                'smv.config.keys=src', 'smv.config.src=cmd',
+                '-m', "modules.A"]
+
+    def test_run_module_with_cmd_run_config(self):
+        self.smvApp.j_smvApp.run()
+        res = self.smvApp.runModule(self.modUrn)
+        expected = self.createDF('src:String', 'cmd')
+        self.should_be_same(res, expected)
+
+    def test_run_module_with_dynamic_run_config(self):
+        self.smvApp.j_smvApp.run()
+        a = self.smvApp.runModule(self.modUrn, {src: 'dynamic_a'})
+        self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
+        b = self.smvApp.runModule(self.modUrn, {src: 'dynamic_b'})
+        self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))

--- a/src/test/python/testDynamicRunConfig/stage/modules.py
+++ b/src/test/python/testDynamicRunConfig/stage/modules.py
@@ -1,0 +1,20 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from smv import SmvApp, SmvModule
+
+class A(SmvModule):
+    def isEphemeral(self): return True
+    def requiresDS(self): return []
+    def run(self, i):
+        return self.smvApp.createDF("src:String", self.smvGetRunConfig("src"))

--- a/src/test/python/testDynamicRunConfig/stage/modules.py
+++ b/src/test/python/testDynamicRunConfig/stage/modules.py
@@ -11,8 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from smv import SmvApp, SmvModule
-from smv.runconfig import SmvRunConfig
+from smv import SmvApp, SmvModule, SmvRunConfig
 
 class A(SmvModule, SmvRunConfig):
     def isEphemeral(self): return True

--- a/src/test/python/testDynamicRunConfig/stage/modules.py
+++ b/src/test/python/testDynamicRunConfig/stage/modules.py
@@ -12,8 +12,9 @@
 # limitations under the License.
 
 from smv import SmvApp, SmvModule
+from smv.runconfig import SmvRunConfig
 
-class A(SmvModule):
+class A(SmvModule, SmvRunConfig):
     def isEphemeral(self): return True
     def requiresDS(self): return []
     def run(self, i):

--- a/src/test/scala/org/tresamigos/smv/SmvAppTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvAppTest.scala
@@ -41,8 +41,23 @@ package org.tresamigos.smv {
         "--input-dir",
         testcaseTempDir,
         "--smv-props",
-        "smv.stages=org.tresamigos.smv.fixture.smvapptest"
+        "smv.stages=org.tresamigos.smv.fixture.smvapptest",
+        "smv.config.keys=sample",
+        "smv.config.sample=1pct"
       )
+
+    test("Test runtime configuration") {
+      import org.tresamigos.smv.fixture.smvapptest._
+      resetTestcaseTempDir()
+
+      assert(app.smvConfig.getRunConfig("sample") === "1pct")
+
+      app.runModule(C.urn, runConfig = Map("sample" -> "2pct"))
+      assert(app.smvConfig.getRunConfig("sample") === "2pct")
+
+      app.runModule(C.urn, runConfig = Map("sample" -> "3pct"))
+      assert(app.smvConfig.getRunConfig("sample") === "3pct")
+    }
 
     test("Test normal dependency execution") {
       import org.tresamigos.smv.fixture.smvapptest._


### PR DESCRIPTION
Fixes #1050 

Method `runModule` accepts `run_config` as dynamic runtime configuration. And the dynamic runtime configuration is always reset before every run operation.
