### PR TITLE
#1053: fix smv release to avoid jdk 8 classes

### DIFF
--- a/admin/smv-release
+++ b/admin/smv-release
@@ -4,12 +4,6 @@
 
 set -e
 PROG_NAME=$(basename "$0")
-SMV_ADMIN="$(cd "`dirname "$0"`"; pwd)"
-SMV_DIR="$(dirname "$SMV_ADMIN")"
-SMV_DIR_BASE="$(basename $SMV_DIR)"
-DOCKER_SMV_DIR="/projects/${SMV_DIR_BASE}" # SMV dir inside the docker image.
-PROJ_DIR="$(dirname "$SMV_DIR")" # assume parent of SMV directory is the projects dir.
-GHPAGES_DIR="${HOME}/.smv/ghpages"
 
 
 function info()
@@ -22,28 +16,19 @@ function error()
 {
   echo "ERROR: $@"
   echo "ERROR: $@" >> ${LOGFILE}
-  echo "(See ${LOGDIR} for error logs/assets)"
+  echo "(See ${BUILD_DIR} for error logs/assets)"
   exit 1
 }
 
 function usage()
 {
-  echo "USAGE: ${PROG_NAME} [--new-branch] -g github_user:github_token -d docker_user docker_password smv_version_to_release(a.b.c.d)"
+  echo "USAGE: ${PROG_NAME} [--new-branch] [--latest] build_dir branch_name github_user:github_token docker_user docker_password smv_version_to_release(a.b.c.d)"
   echo "See (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for auth tokens"
   exit $1
 }
 
-function create_logdir()
-{
-  LOGDIR="${TMPDIR-/tmp}/smv_release_$(date +%Y%m%d_%s)"
-  LOGFILE="${LOGDIR}/${PROG_NAME}.log"
-  mkdir -p "${LOGDIR}"
-  info "logs/assets can be found in: ${LOGDIR}"
-}
-
 function parse_args()
 {
-  info "parsing command line args"
   [ "$1" = "-h" ] && usage 0
 
   NEW_BRANCH=0
@@ -59,23 +44,49 @@ function parse_args()
   fi
 
   [ $# -ne 6 ] && echo "ERROR: invalid number of arguments" && usage 1
-  [ "$1" != "-g" ] && echo "ERROR: must supply github user name/token" && usage 1
-  [ "$3" != "-d" ] && echo "ERROR: must supply dockerhub user name/password" && usage 1
 
-  GITHUB_USER_TOKEN="$2"
+  BUILD_DIR="$1"
+  SMV_BRANCH="$2"
+  GITHUB_USER_TOKEN="$3"
   DOCKERHUB_USER_NAME="$4"
   DOCKERHUB_USER_PASSWORD="$5"
   SMV_VERSION="$6"
+
   validate_version "$SMV_VERSION"
+  if [ ! -d "${BUILD_DIR}" ]; then
+    echo "ERROR: ${BUILD_DIR} is not a valid build directory"
+    exit 1
+  fi
 
   # version specific vars
-  TGZ_IMAGE="${LOGDIR}/smv_${SMV_VERSION}.tgz"
-  DOCS_DIR="${LOGDIR}/docs"
+  LOGFILE="${BUILD_DIR}/smv-release.log"
+  rm -f "${LOGFILE}"
+  TGZ_IMAGE="${BUILD_DIR}/smv_${SMV_VERSION}.tgz"
+  DOCS_DIR="${BUILD_DIR}/docs"
+
+  # release specific vars
+  SMV_DIR_BASE="SMV_${SMV_VERSION}"
+  SMV_DIR="${BUILD_DIR}/${SMV_DIR_BASE}"
+  DOCKER_SMV_DIR="/projects/${SMV_DIR_BASE}" # SMV dir inside the docker image.
+  PROJ_DIR="$(dirname "$SMV_DIR")" # assume parent of SMV directory is the projects dir.
+
+  GHPAGES_DIR="${HOME}/.smv/ghpages"
+  SMV_REPO_URL="git@github.com:TresAmigosSD/SMV.git"
+}
+
+function clone_repo()
+{
+  info "cloning SMV repo branch: ${SMV_BRANCH}"
+  cd "${PROJ_DIR}"
+  rm -rf "${SMV_DIR_BASE}"
+  git clone -b "${SMV_BRANCH}" "${SMV_REPO_URL}" "${SMV_DIR_BASE}"\
+    >> ${LOGFILE} 2>&1 || error "cloning SMV ${SMV_BRANCH}"
 }
 
 function check_for_existing_tag()
 {
   info "checking for existing tag"
+  cd "${SMV_DIR}"
   if [ $(git tag -l "v${SMV_VERSION}" | wc -l) -eq 1 ]; then
     error version ${SMV_VERSION} already exists.
   fi
@@ -99,17 +110,33 @@ function validate_version()
   fi
 }
 
-function build_smv()
+function run_sbt_in_docker()
 {
-  info "Building SMV"
+  local target="$1"
+  info "Running sbt ${target}"
+
   # explicitly add -ivy flag as SMV docker image is not picking up sbtopts file. (SMV issue #556)
   docker run --rm -it -v ${PROJ_DIR}:/projects tresamigos/smv:latest \
     -u $(id -u)\
-    sh -c "cd $DOCKER_SMV_DIR; sbt -ivy /projects/.ivy2 clean assembly" \
-    >> ${LOGFILE} 2>&1 || error "SMV build failed"
+    sh -c "cd $DOCKER_SMV_DIR; sbt -ivy /projects/.ivy2 $target" \
+    >> ${LOGFILE} 2>&1 || error "SMV sbt $target failed"
+}
 
+function build_smv()
+{
+  info "Building SMV"
+  run_sbt_in_docker clean
+  run_sbt_in_docker assembly
+}
+
+function test_smv()
+{
   info "Testing SMV"
-  sbt alltest >> ${LOGFILE} 2>&1 || error "SMV Test failed"
+
+  # need to decompose the "alltest" target as the memory leak causes docker build to fail.
+  run_sbt_in_docker test
+  run_sbt_in_docker pytest
+  run_sbt_in_docker itest
 }
 
 # find the gnu tar on this system.
@@ -140,15 +167,6 @@ function find_release_msg_file()
   cd "${SMV_DIR}"
   if [ ! -r "${RELEASE_MSG_FILE}" ]; then
     error "Unable to find release message file: ${RELEASE_MSG_FILE}"
-  fi
-}
-
-function check_git_repo()
-{
-  info "checking repo for modified files"
-  cd "${SMV_DIR}"
-  if [ -n "$(git diff-index --quiet HEAD -- | grep -v smv-release)" ]; then
-    error "SMV git repo has locally modified files"
   fi
 }
 
@@ -205,7 +223,6 @@ function create_tar()
 
   # create the tar image
   ${TAR} zcvf "${TGZ_IMAGE}" -C "${PROJ_DIR}" --exclude=.git --exclude="admin" \
-    --transform "s/^${SMV_DIR_BASE}/SMV_${SMV_VERSION}/" \
     ${SMV_DIR_BASE} >> ${LOGFILE} 2>&1 || error "tar creation failed"
 }
 
@@ -213,8 +230,8 @@ function create_tar()
 function create_github_release()
 {
   info "Create github release"
-  local body_file="${LOGDIR}/req1.body.json"
-  local res_file="${LOGDIR}/res1.json"
+  local body_file="${BUILD_DIR}/req1.body.json"
+  local res_file="${BUILD_DIR}/res1.json"
   local rel_doc_url="https://github.com/TresAmigosSD/SMV/blob/v${SMV_VERSION}/releases/v${SMV_VERSION}.md"
 
   # create POST request body for creating the repo.
@@ -242,7 +259,7 @@ function create_github_release()
 function attach_tar_to_github_release()
 {
   info "attach tar image to github release"
-  local res_file="${LOGDIR}/res2.json"
+  local res_file="${BUILD_DIR}/res2.json"
   local tgz_basename="$(basename ${TGZ_IMAGE})"
 
   curl -i -u "${GITHUB_USER_TOKEN}" \
@@ -282,7 +299,7 @@ function create_docker_image()
 function gen_pydocs()
 {
   info "generating python docs"
-  local smv_py_dir="/projects/SMV/src/main/python"
+  local smv_py_dir="${DOCKER_SMV_DIR}/src/main/python"
   local spark_py_dir="/usr/lib/spark/python"
   mkdir -p ${DOCS_DIR}/python
 
@@ -336,7 +353,7 @@ function get_latest_ghpages()
     (cd "${GHPAGES_DIR}/SMV"; git pull) \
       >> ${LOGFILE} 2>&1 || error "pulling latest SMV ghpages"
   else
-    git clone -b gh-pages git@github.com:TresAmigosSD/SMV.git \
+    git clone -b gh-pages "${SMV_REPO_URL}" \
       >> ${LOGFILE} 2>&1 || error "cloning SMV ghpages"
   fi
 }
@@ -379,15 +396,15 @@ function push_ghpages_docs()
 }
 
 # ---- MAIN ----
-create_logdir
-info "Start Release on: $(date)"
 parse_args "$@"
+info "Start Release on: $(date)"
+clone_repo
 check_for_existing_tag
 get_prev_smv_version
 find_gnu_tar
 find_release_msg_file
-check_git_repo
 build_smv
+test_smv
 gen_pydocs
 gen_scaladocs
 update_version
@@ -395,8 +412,8 @@ tag_release
 create_tar
 create_github_release
 attach_tar_to_github_release
-create_docker_image
 get_latest_ghpages
 update_ghpages_docs
 push_ghpages_docs
+create_docker_image
 info "Finish Release on: $(date)"

--- a/src/main/python/smv/utils.py
+++ b/src/main/python/smv/utils.py
@@ -34,7 +34,7 @@ def iter_submodules_in_stage(stage):
     # Gtk modules, which are not designed to use with reflection or
     # introspection. Best action to take in this situation is probably
     # to simply suppress the error.
-    def onerror(): pass
+    def onerror(n): pass
     return pkgutil.walk_packages(stagemod.__path__, stagemod.__name__ + '.' , onerror=onerror)
 
 def for_name(name, stages):


### PR DESCRIPTION
Fixes #1053 
* clones SMV repo on each build to avoid any old artifacts and symlink issues.
* allows user to specify a build dir instead of using a timestamp dir in /tmp
* minor fix for `onerror` missing arg.
  