### PR TITLE
i1069 fix Py4J error in module discovery when file contains JavaObject

### DIFF
--- a/src/test/python/testDataSetRepo/java_obj/stage/modules.py
+++ b/src/test/python/testDataSetRepo/java_obj/stage/modules.py
@@ -1,0 +1,7 @@
+import smv
+
+java_obj = smv.smvapp.SmvApp.getInstance().j_smvApp
+
+class WhateverModule(smv.SmvModule):
+    def run(self, i): return None
+    def requiresDS(self): return None


### PR DESCRIPTION
Fixes #1069. Includes a small cleanup of the implementation of `datasetsForStage`.