### PR TITLE
I1080 Easy Python API for DQM Validation Result

### DIFF
--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -189,7 +189,7 @@ def getDatasetInstance(fqn):
 
 def runModule(fqn, run_config=None):
     '''runs module of given fqn and runtime configuration'''
-    return SmvApp.getInstance().runModule("mod:{}".format(fqn), runConfig=run_config)
+    return SmvApp.getInstance().runModule("mod:{}".format(fqn), runConfig=run_config)[0]
 
 def getMetadataJson(fqn):
     '''returns metadata given a fqn'''

--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -1,0 +1,49 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Easy Python access to SmvRunInfoCollector and related Scala classes.
+
+Todo:
+    * document example use
+"""
+
+import json
+
+class SmvRunInfoCollector(object):
+    """Python wrapper to its counterpart on the Scala side
+
+    Example:
+        df, coll = smvApp.runModule(...)
+        coll.dsFqns  # returns
+    """
+    def __init__(self, jcollector):
+        self.jcollector = jcollector
+
+    def fqns(self):
+        """Returns a list of FQNs for all datasets that ran"""
+        return self.jcollector.dsFqnsAsJava()
+
+    def dqm_validation(self, dsFqn):
+        """Returns the DQM validation result for a given dataset
+
+        Returns:
+            A dictionary representation of the dqm validation result
+
+        Raises:
+            py4j.protocol.Py4JError: if there is java call error or
+                there is no validation result for the specified dataset
+                (e.g. caused by a typo in the name)
+
+        """
+        java_result = self.jcollector.getDqmValidationResult(dsFqn)
+        return json.loads(java_result.toJSON())

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -29,6 +29,7 @@ from smv.utils import smv_copy_array, check_socket
 from smv.error import SmvRuntimeError
 import smv.helpers
 from smv.utils import FileObjInputStream
+from smv.runinfo import SmvRunInfoCollector
 
 class SmvApp(object):
     """The Python representation of SMV.
@@ -195,8 +196,9 @@ class SmvApp(object):
             - SmvRunInfoCollector contains additional information
               about the run, such as validation results.
         """
-        result = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version), runConfig)
-        return DataFrame(result.df(), self.sqlContext), result.collector()
+        java_result = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version), runConfig)
+        return (DataFrame(java_result.df(), self.sqlContext),
+                SmvRunInfoCollector(java_result.collector()) )
 
     def runModuleByName(self, name, forceRun = False, version = None, runConfig = None):
         """Runs a SmvModule by its name (can be partial FQN)
@@ -209,8 +211,9 @@ class SmvApp(object):
             - SmvRunInfoCollector contains additional information
               about the run, such as validation results.
         """
-        result = self.j_smvPyClient.runModuleByName(name, forceRun, self.scalaOption(version), runConfig)
-        return DataFrame(result.df(), self.sqlContext), result.collector()
+        java_result = self.j_smvPyClient.runModuleByName(name, forceRun, self.scalaOption(version), runConfig)
+        return (DataFrame(java_result.df(), self.sqlContext),
+                SmvRunInfoCollector(java_result.collector()) )
 
     def getMetadataJson(self, urn):
         """Returns the metadata for a given urn"""

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -182,12 +182,33 @@ class SmvApp(object):
 
         Use j_smvPyClient instead of j_smvApp directly so we don't
         have to construct SmvRunCollector from the python side.
+
+        Example:
+            To get just the dataframe of the module:
+                dataframe = smvApp.runModule('mod:package.module.SmvModuleClass')[0]
+            To get both the dataframe and the run info collector:
+                dataframe, collector = smvApp.runModule('mod:package.module.SmvModuleClass')
+
+        Returns:
+            (DataFrame, SmvRunInfoCollector) tuple
+            - DataFrame is the computed result of the module
+            - SmvRunInfoCollector contains additional information
+              about the run, such as validation results.
         """
         result = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version), runConfig)
         return DataFrame(result.df(), self.sqlContext), result.collector()
 
     def runModuleByName(self, name, forceRun = False, version = None, runConfig = None):
-        """Runs a SmvModule by its name (can be partial FQN)"""
+        """Runs a SmvModule by its name (can be partial FQN)
+
+        See the `runModule` method above
+
+        Returns:
+            (DataFrame, SmvRunInfoCollector) tuple
+            - DataFrame is the computed result of the module
+            - SmvRunInfoCollector contains additional information
+              about the run, such as validation results.
+        """
         result = self.j_smvPyClient.runModuleByName(name, forceRun, self.scalaOption(version), runConfig)
         return DataFrame(result.df(), self.sqlContext), result.collector()
 

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -186,9 +186,9 @@ class SmvApp(object):
         result = self.j_smvPyClient.runModule(urn, forceRun, self.scalaOption(version), runConfig)
         return DataFrame(result.df(), self.sqlContext), result.collector()
 
-    def runModuleByName(self, name, forceRun = False, version = None):
+    def runModuleByName(self, name, forceRun = False, version = None, runConfig = None):
         """Runs a SmvModule by its name (can be partial FQN)"""
-        result = self.j_smvPyClient.runModuleByName(name, forceRun, self.scalaOption(version))
+        result = self.j_smvPyClient.runModuleByName(name, forceRun, self.scalaOption(version), runConfig)
         return DataFrame(result.df(), self.sqlContext), result.collector()
 
     def getMetadataJson(self, urn):

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -35,7 +35,7 @@ def df(name, forceRun = False, version = None):
         Returns:
             (DataFrame): The result of running the named module.
     """
-    return SmvApp.getInstance().runModuleByName(name, forceRun, version)
+    return SmvApp.getInstance().runModuleByName(name, forceRun, version)[0]
 
 def dshash(name):
     """The current hashOfHash for the named module as a hex string

--- a/src/main/python/test_support/smvbasetest.py
+++ b/src/main/python/test_support/smvbasetest.py
@@ -83,7 +83,7 @@ class SmvBaseTest(unittest.TestCase):
 
     @classmethod
     def df(cls, fqn):
-        return cls.smvApp.runModule("mod:" + fqn)
+        return cls.smvApp.runModule("mod:" + fqn)[0]
 
     def should_be_same(self, expected, result):
         """Asserts that the two dataframes contain the same data, ignoring order

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -367,9 +367,10 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   def runModuleByName(modName: String,
                       forceRun: Boolean = false,
                       version: Option[String] = None,
+                      runConfig: Map[String, String] = Map.empty,
                       collector: SmvRunInfoCollector = new SmvRunInfoCollector): DataFrame = {
     val ds = dsm.inferDS(modName).head
-    runDS(ds, forceRun, version, collector=collector)
+    runDS(ds, forceRun, version, runConfig, collector=collector)
   }
 
   /**

--- a/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
@@ -14,6 +14,8 @@
 
 package org.tresamigos.smv
 
+import scala.collection.JavaConverters._
+
 import dqm.DqmValidationResult
 
 class SmvRunInfoCollector {
@@ -34,6 +36,9 @@ class SmvRunInfoCollector {
 
   /** Returns the set of fqns of the datasets that ran */
   def dsFqns: Set[String] = results.keySet
+
+  /** For use by Python side */
+  def dsFqnsAsJava: java.util.List[String] = dsFqns.toSeq.asJava
 
   /**
    * Returns the DQM validation result for a given dataset

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -265,9 +265,11 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   /** Runs an SmvModule written in either Python or Scala */
   def runModuleByName(name: String,
                 forceRun: Boolean,
-                version: Option[String]): RunModuleResult = {
+                version: Option[String],
+                runConfig: java.util.Map[String, String]): RunModuleResult = {
+    val dynamicRunConfig: Map[String, String] = if (null == runConfig) Map.empty else mapAsScalaMap(runConfig).toMap
     val collector = new SmvRunInfoCollector
-    val df =  j_smvApp.runModuleByName(name, forceRun, version, collector)
+    val df =  j_smvApp.runModuleByName(name, forceRun, version, dynamicRunConfig, collector)
     RunModuleResult(df, collector)
   }
 

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -262,6 +262,15 @@ class SmvPyClient(val j_smvApp: SmvApp) {
     RunModuleResult(df, collector)
   }
 
+  /** Runs an SmvModule written in either Python or Scala */
+  def runModuleByName(name: String,
+                forceRun: Boolean,
+                version: Option[String]): RunModuleResult = {
+    val collector = new SmvRunInfoCollector
+    val df =  j_smvApp.runModuleByName(name, forceRun, version, collector)
+    RunModuleResult(df, collector)
+  }
+
   def copyToHdfs(in: IAnyInputStream, dest: String): Unit =
     SmvHDFS.writeToFile(in, dest)
 

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -25,16 +25,16 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
 
     def test_run_module_with_cmd_run_config(self):
         self.smvApp.j_smvApp.run()
-        res = self.smvApp.runModule(self.modUrn)
+        res = self.smvApp.runModule(self.modUrn)[0]
         expected = self.createDF('src:String', 'cmd')
         self.should_be_same(res, expected)
 
     def test_run_module_with_dynamic_run_config(self):
         self.smvApp.j_smvApp.run()
-        a = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_a'})
+        a = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_a'})[0]
         self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
-        b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})
+        b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})[0]
         self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))
 
-        c = self.smvApp.runModule(self.modUrn)
+        c = self.smvApp.runModule(self.modUrn)[0]
         self.should_be_same(c, self.createDF('src:String', 'cmd'))

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -16,6 +16,7 @@ from smv import SmvApp
 
 class RunModuleWithRunConfigTest(SmvBaseTest):
     modUrn = 'mod:stage.modules.A'
+    modName = 'modules.A'
 
     @classmethod
     def smvAppInitArgs(cls):
@@ -27,14 +28,19 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
         self.smvApp.j_smvApp.run()
         res = self.smvApp.runModule(self.modUrn)[0]
         expected = self.createDF('src:String', 'cmd')
-        self.should_be_same(res, expected)
+        self.should_be_same(expected, res)
 
     def test_run_module_with_dynamic_run_config(self):
         self.smvApp.j_smvApp.run()
         a = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_a'})[0]
-        self.should_be_same(a, self.createDF('src:String', 'dynamic_a'))
+        self.should_be_same(self.createDF('src:String', 'dynamic_a'), a)
         b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})[0]
-        self.should_be_same(b, self.createDF('src:String', 'dynamic_b'))
+        self.should_be_same(self.createDF('src:String', 'dynamic_b'), b)
 
         c = self.smvApp.runModule(self.modUrn)[0]
-        self.should_be_same(c, self.createDF('src:String', 'cmd'))
+        self.should_be_same(self.createDF('src:String', 'cmd'), c)
+
+    def test_run_module_by_name_with_run_config(self):
+        df, collector = self.smvApp.runModuleByName(self.modName)
+        expected = self.createDF('src:String', 'cmd')
+        self.should_be_same(expected, df)

--- a/src/test/python/testRunCmdLine.py
+++ b/src/test/python/testRunCmdLine.py
@@ -24,7 +24,7 @@ class RunModuleFromCmdLineTest(SmvBaseTest):
 
     def test_can_run_module_from_cmdline(self):
         self.smvApp.j_smvApp.run()
-        a = self.smvApp.runModule(self.modUrn)
+        a = self.smvApp.runModule(self.modUrn)[0]
         expected = self.createDF("k:String;v:Integer", "a,;b,2")
         self.should_be_same(a, expected)
 
@@ -38,7 +38,7 @@ class RunStageFromCmdLineTest(SmvBaseTest):
 
     def test_can_run_stage_from_cmdline(self):
         self.smvApp.j_smvApp.run()
-        a = self.smvApp.runModule("mod:" + self.stageName + ".modules.A")
+        a = self.smvApp.runModule("mod:" + self.stageName + ".modules.A")[0]
         self.should_be_same(a, self.createDF("k:String;v:Integer", "a,;b,2"))
-        b = self.smvApp.runModule("mod:" + self.stageName + ".modules.B")
+        b = self.smvApp.runModule("mod:" + self.stageName + ".modules.B")[0]
         self.should_be_same(b, self.createDF("k:String;v:Integer", "c,3;d,4"))

--- a/tools/conf/smv_pyshell_init.py.template
+++ b/tools/conf/smv_pyshell_init.py.template
@@ -43,6 +43,32 @@ if os.path.exists(historyPath):
 
 atexit.register(save_history)
 
+# temporary: inspect validation result
+def showRunCollector(collector):
+    print('datasets: %s' % collector.dsFqns().toString())
+    if collector.dsFqns().isEmpty():
+        print('collector is empty')
+        return
+
+    fqn = collector.dsFqns().toSeq().apply(0)
+    print('first dataset: %s' % fqn)
+    print('dqm validation result is %s' % collector.getDqmValidationResult(fqn).toString())
+
+    validation = collector.getDqmValidationResult(fqn)
+    print('-- passed is %s' % validation.passed())
+
+    dqmstate = validation.dqmStateSnapshot()
+    print('-- dqm state is %s' % dqmstate.toString())
+    if (dqmstate):
+        print('---- dqmstate.totalrecords is %s' % dqmstate.totalRecords())
+        print('---- dqmstate.parsererror is %s' % dqmstate.parseError().toString())
+        print('---- dqmstate.fixcounts is %s' % dqmstate.fixCounts().toString())
+        print('---- dqmstate.ruleerrors is %s' % dqmstate.ruleErrors().toString())
+        pass
+
+    print('-- err msgs is %s' % validation.errorMessages().toString())
+    print('-- check log is %s' % validation.checkLog().toString())
+
 # Get a random port for callback server
 import random;
 callback_server_port = random.randint(20000, 65535)

--- a/tools/conf/smv_pyshell_init.py.template
+++ b/tools/conf/smv_pyshell_init.py.template
@@ -20,6 +20,7 @@ Initializes Smv in Pyspark Shell
 
 import atexit
 import os
+from pprint import pprint, pformat
 try:
     import readline
 except ImportError:
@@ -43,31 +44,13 @@ if os.path.exists(historyPath):
 
 atexit.register(save_history)
 
-def showRunCollector(collector):
+def show_run_info(collector):
     """Inspects the SmvRunInfoCollector object returned by smvApp.runModule"""
-    print('datasets: %s' % collector.dsFqns().toString())
-    if collector.dsFqns().isEmpty():
-        print('collector is empty')
-        return
-
-    fqn = collector.dsFqns().toSeq().apply(0)
-    print('first dataset: %s' % fqn)
-    print('dqm validation result is %s' % collector.getDqmValidationResult(fqn).toString())
-
-    validation = collector.getDqmValidationResult(fqn)
-    print('-- passed is %s' % validation.passed())
-
-    dqmstate = validation.dqmStateSnapshot()
-    print('-- dqm state is %s' % dqmstate.toString())
-    if (dqmstate):
-        print('---- dqmstate.totalrecords is %s' % dqmstate.totalRecords())
-        print('---- dqmstate.parsererror is %s' % dqmstate.parseError().toString())
-        print('---- dqmstate.fixcounts is %s' % dqmstate.fixCounts().toString())
-        print('---- dqmstate.ruleerrors is %s' % dqmstate.ruleErrors().toString())
-        pass
-
-    print('-- err msgs is %s' % validation.errorMessages().toString())
-    print('-- check log is %s' % validation.checkLog().toString())
+    print('datasets: %s' % collector.fqns())
+    for fqn in collector.fqns():
+        print('+ %s' % fqn)
+        print('`-- dqm validation:')
+        print('    '+ pformat(collector.dqm_validation(fqn), indent=4))
 
 # Get a random port for callback server
 import random;

--- a/tools/conf/smv_pyshell_init.py.template
+++ b/tools/conf/smv_pyshell_init.py.template
@@ -43,8 +43,8 @@ if os.path.exists(historyPath):
 
 atexit.register(save_history)
 
-# temporary: inspect validation result
 def showRunCollector(collector):
+    """Inspects the SmvRunInfoCollector object returned by smvApp.runModule"""
     print('datasets: %s' % collector.dsFqns().toString())
     if collector.dsFqns().isEmpty():
         print('collector is empty')


### PR DESCRIPTION
Closes #1080

### PR #1079 should be merged first, as this is branched off from that.

#### Summary
- Take advantage of JSON serialization to turn Scala `DqmValidationResult` into a Python dictionary.