### PR TITLE
#1090: use 1.6 for source/target of java code compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalaVersion := "2.10.4"
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
+javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
+
 val sparkVersion = "1.5.2"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Fixes #1090 