### PR TITLE
dependency graph json string returns description metadata as defined in python module

### DIFF
--- a/src/main/java/org/tresamigos/smv/ISmvModule.java
+++ b/src/main/java/org/tresamigos/smv/ISmvModule.java
@@ -28,6 +28,7 @@ import org.tresamigos.smv.dqm.DQMValidator;
  * decorator to ensure that errors that occur in callbacks don't get eaten.
  */
 public interface ISmvModule {
+	IPythonResponsePy4J<String> getDescription();
 	/**
 	 * Does the result of this module need to be persisted?
 	 *

--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -103,6 +103,8 @@ class SmvDataSet(ABC):
     def description(self):
         return self.__doc__
 
+    getDescription = create_py4j_interface_method("getDescription", "description")
+
     # this doesn't need stack trace protection
     @abc.abstractmethod
     def requiresDS(self):

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -1049,7 +1049,7 @@ case class SmvExtModuleLink(modFqn: String)
  */
 class SmvExtModulePython(target: ISmvModule) extends SmvDataSet with python.InterfacesWithPy4J {
   override val fqn            = getPy4JResult(target.getFqn)
-  override val description    = s"SmvModule ${fqn}"
+  override val description    = getPy4JResult(target.getDescription)
   override def tableName      = getPy4JResult(target.getTableName)
   override def isEphemeral    = getPy4JResult(target.getIsEphemeral)
   override def publishHiveSql = Option(getPy4JResult(target.getPublishHiveSql))

--- a/src/main/scala/org/tresamigos/smv/graph/SmvStageGraph.scala
+++ b/src/main/scala/org/tresamigos/smv/graph/SmvStageGraph.scala
@@ -17,6 +17,8 @@ package graph
 
 import com.github.mdr.ascii.graph.{Graph => AsciiGraph}
 import com.github.mdr.ascii.layout.{GraphLayout => AsciiGraphLayout}
+import scala.reflect.runtime.universe.{Constant, Literal}
+
 /**
  * Arbitrary SmvDataSet graph
  * Nodes are SmvDataSets and edges are the dependency of DSs
@@ -221,6 +223,7 @@ private[smv] class SmvGraphUtil(app: SmvApp, pstages: Seq[String] = Nil) {
 
     def toNodeStr(m: SmvDataSet) = {
       val dsType = m.dsType
+      val escapedDescription = Literal(Constant(m.description)).toString()
       val nodeType = if (dsType == "Input") "file" else (
         // convert the first character of dsType to lowercase
         dsType.substring(0, 1).toLowerCase() + dsType.substring(1))
@@ -229,7 +232,7 @@ private[smv] class SmvGraphUtil(app: SmvApp, pstages: Seq[String] = Nil) {
       s"""    "type": "${nodeType}",""" + "\n" +
       s"""    "version": ${m.version},""" + "\n" +
       s"""    "needsToRun": ${m.needsToRun},""" + "\n" +
-      s"""    "description": "${m.description}"""" + "\n" +
+      s"""    "description": ${escapedDescription}""" + "\n" +
       s"""  }"""
     }
 


### PR DESCRIPTION
Fixes #1095 

Previously, the `createGraphJson` method in `SmvStageGraph` used to return a hardcoded string and fqn  (`SMVModule {fqn}`) for python module's description metadata.
After this PR, the description metadata's of a python module is always displayed in the stage graph json string.

A more long term solution will be implemented in #1092 