### PR TITLE
I1086: Python and Scala API to get RunInfo for a module

### DIFF
--- a/docs/dev/SmvDQM/SmvDQM.md
+++ b/docs/dev/SmvDQM/SmvDQM.md
@@ -166,7 +166,7 @@ we don't need to run `checkDQM` or `checkParserLogger` anymore.
 
 Let's modify the `checkResult` part of the `computeRDD` method
 ```scala
-val checkResult = readPersistsedCheckFile() recoverWith {case e =>
+val checkResult = readPersistedCheckFile() recoverWith {case e =>
   if(!hasAction) df.count
   val res = checkParserLogger ++ df.checkDQM
   res.persist
@@ -218,7 +218,7 @@ The `validate` method of `ValidationSet` will looks like:
 ```scala
 def validate(df: DataFrame, hasActionYet: Boolean) = {
   val needAction = tasks.map{t => t.needAction}.reduce(_ || _)
-  val result = readPersistsedCheckFile() recover with {case e =>
+  val result = readPersistedCheckFile() recover with {case e =>
     if((!hasActionYet) && needAction) forceAction(df)
     val res = tasks.map{t => t.validate(df)}.reduce(_ ++ _)
     persiste(res)

--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -19,6 +19,7 @@ Todo:
 
 import json
 
+
 class SmvRunInfoCollector(object):
     """Python wrapper to its counterpart on the Scala side
 
@@ -46,6 +47,8 @@ class SmvRunInfoCollector(object):
 
         """
         java_result = self.jcollector.getDqmValidationResult(dsFqn)
+        if java_result is None:
+            return None
         return json.loads(java_result.toJSON())
 
     def metadata(self, dsFqn):
@@ -61,6 +64,8 @@ class SmvRunInfoCollector(object):
 
         """
         java_result = self.jcollector.getMetadata(dsFqn)
+        if java_result is None:
+            return None
         return json.loads(java_result.toJson())
 
     def metadata_history(self, dsFqn):
@@ -76,4 +81,6 @@ class SmvRunInfoCollector(object):
 
         """
         java_result = self.jcollector.getMetadataHistory(dsFqn)
+        if java_result is None:
+            return None
         return json.loads(java_result.toJson())

--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -48,7 +48,7 @@ class SmvRunInfoCollector(object):
         """
         java_result = self.jcollector.getDqmValidationResult(dsFqn)
         if java_result is None:
-            return None
+            return {}
         return json.loads(java_result.toJSON())
 
     def metadata(self, dsFqn):
@@ -65,7 +65,7 @@ class SmvRunInfoCollector(object):
         """
         java_result = self.jcollector.getMetadata(dsFqn)
         if java_result is None:
-            return None
+            return {}
         return json.loads(java_result.toJson())
 
     def metadata_history(self, dsFqn):
@@ -82,5 +82,5 @@ class SmvRunInfoCollector(object):
         """
         java_result = self.jcollector.getMetadataHistory(dsFqn)
         if java_result is None:
-            return None
+            return {}
         return json.loads(java_result.toJson())

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -215,6 +215,27 @@ class SmvApp(object):
         return (DataFrame(java_result.df(), self.sqlContext),
                 SmvRunInfoCollector(java_result.collector()) )
 
+    def getRunInfo(self, urn):
+        """Returns the run information of a module and all its dependencies
+        from the last run.
+
+        Unlike the runModule() method, which returns the run
+        information just for that run, this method returns the run
+        information from the last run.
+
+        If no module was run (e.g. the code did not change, so the
+        data is read from persistent storage), the SmRunInfoCollector
+        returned from the runModule() method would be empty.  But the
+        SmvRunInfoCollector returned from this method would contain
+        all latest run information about all dependent modules.
+
+        Returns:
+            SmvRunInfoCollector
+
+        """
+        java_result = self.j_smvPyClient.getRunInfo(urn)
+        return SmvRunInfoCollector(java_result)
+
     def getMetadataJson(self, urn):
         """Returns the metadata for a given urn"""
         return self.j_smvPyClient.getMetadataJson(urn)

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -373,6 +373,23 @@ class SmvApp(private val cmdLineArgs: Seq[String],
     runDS(ds, forceRun, version, runConfig, collector=collector)
   }
 
+  def getRunInfo(partialName: String): SmvRunInfoCollector =
+    getRunInfo(dsm.inferDS(partialName).head)
+
+  def getRunInfo(urn: URN): SmvRunInfoCollector =
+    getRunInfo(dsm.load(urn).head)
+
+  /**
+   * Returns the run information for a given dataset and all its
+   * dependencies (including transitive dependencies), from the last run
+   */
+  def getRunInfo(ds: SmvDataSet,
+    coll: SmvRunInfoCollector=new SmvRunInfoCollector()): SmvRunInfoCollector = {
+    coll.addRunInfo(ds.fqn, ds.runInfo)
+    ds.requiresDS foreach (getRunInfo(_, coll))
+    coll
+  }
+
   /**
    * Returns metadata for a given urn
    */

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -386,7 +386,7 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   def getRunInfo(ds: SmvDataSet,
     coll: SmvRunInfoCollector=new SmvRunInfoCollector()): SmvRunInfoCollector = {
     coll.addRunInfo(ds.fqn, ds.runInfo)
-    ds.requiresDS foreach (getRunInfo(_, coll))
+    ds.resolvedRequiresDS foreach (getRunInfo(_, coll))
     coll
   }
 

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -493,6 +493,19 @@ abstract class SmvDataSet extends FilenamePart {
     }
   }
 
+  /**
+   * Returns the run information from this dataset's last run.
+   *
+   * If the dataset has never been run, returns an empty run info with
+   * null for its components.
+   */
+  def runInfo: SmvRunInfo = {
+    val validation = DQMValidator.readPersistedValidationFile(moduleValidPath()).toOption.orNull
+    val meta = readPersistedMetadata(moduleMetaPath()).toOption.orNull
+    val mhistory = readMetadataHistory(moduleMetaHistoryPath()).toOption.orNull
+    SmvRunInfo(validation, meta, mhistory)
+  }
+
   /** path to published output without file extension **/
   private[smv] def publishPathNoExt(version: String) = s"${app.smvConfig.publishDir}/${version}/${fqn}"
 

--- a/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
@@ -30,9 +30,12 @@ class SmvRunInfoCollector {
   def addRunInfo(dsFqn: String,
     validation: DqmValidationResult,
     metadata: SmvMetadata,
-    metadataHistory: SmvMetadataHistory): SmvRunInfoCollector = {
+    metadataHistory: SmvMetadataHistory): SmvRunInfoCollector =
+    addRunInfo(dsFqn, SmvRunInfo(validation, metadata, metadataHistory))
+
+  def addRunInfo(dsFqn: String, runInfo: SmvRunInfo): SmvRunInfoCollector = {
     require(dsFqn != null && !dsFqn.isEmpty, s"Dataset FQN [$dsFqn] cannot be empty or null")
-    this.runInfo += dsFqn -> SmvRunInfo(validation, metadata, metadataHistory)
+    this.runInfo += dsFqn -> runInfo
     this
   }
 

--- a/src/main/scala/org/tresamigos/smv/dqm/SmvDQM.scala
+++ b/src/main/scala/org/tresamigos/smv/dqm/SmvDQM.scala
@@ -107,6 +107,8 @@ object SmvDQM {
  *                    for persisted results before running, and persist its own results
  */
 class DQMValidator(dqm: SmvDQM, persistable: Boolean) {
+  import DQMValidator._
+
   private lazy val app: SmvApp = SmvApp.app
 
   private val ruleNames = dqm.rules.map { _.name }
@@ -185,13 +187,6 @@ class DQMValidator(dqm: SmvDQM, persistable: Boolean) {
     }
   }
 
-  private def readPersistsedValidationFile(path: String): Try[DqmValidationResult] = {
-    Try({
-      val json = SmvReportIO.readReport(path)
-      DqmValidationResult.fromJson(json)
-    })
-  }
-
   /**
    * Entrypoint for validating data. Runs validation UNLESS there is a persisted
    * result, in which case returns that result
@@ -204,7 +199,7 @@ class DQMValidator(dqm: SmvDQM, persistable: Boolean) {
 
       val result = if (persistable) {
         // try to read from persisted validation file
-        readPersistsedValidationFile(path).recoverWith {
+        readPersistedValidationFile(path).recoverWith {
           case e => {
             Try(runValidation(df, forceAction, path))
           }
@@ -261,6 +256,11 @@ class DQMValidator(dqm: SmvDQM, persistable: Boolean) {
 
     DqmValidationResult(passed, snapshot, errorMessages, checkLog)
   }
+}
+
+object DQMValidator {
+  def readPersistedValidationFile(path: String): Try[DqmValidationResult] =
+    Try(DqmValidationResult.fromJson(SmvReportIO.readReport(path)))
 }
 
 /**

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -273,6 +273,16 @@ class SmvPyClient(val j_smvApp: SmvApp) {
     RunModuleResult(df, collector)
   }
 
+  /**
+   * Returns the run information of a dataset and all its dependencies
+   * from the last run.
+   */
+  def getRunInfo(urn: String): SmvRunInfoCollector =
+    j_smvApp.getRunInfo(URN(urn))
+
+  def getRunInfoByPartialName(partialName: String): SmvRunInfoCollector =
+    j_smvApp.getRunInfo(partialName)
+
   def copyToHdfs(in: IAnyInputStream, dest: String): Unit =
     SmvHDFS.writeToFile(in, dest)
 

--- a/src/test/python/testSmvRunInfo.py
+++ b/src/test/python/testSmvRunInfo.py
@@ -1,0 +1,60 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+
+from test_support.smvbasetest import SmvBaseTest
+
+
+class SmvRunInfoTest(SmvBaseTest):
+    urn = 'mod:stage.modules.R4'
+
+    @classmethod
+    def smvAppInitArgs(cls):
+        return ['--smv-props', 'smv.stages=stage']
+
+    def setUp(self):
+        """Tests in this class needs clean data directories"""
+        shutil.rmtree(self.tmpDataDir(), ignore_errors=True)
+        os.makedirs(self.tmpDataDir())
+
+    def test_run_info_is_empty_if_no_module_is_run(self):
+        # the first time modules are run, information is collected
+        res, coll = self.smvApp.runModule(self.urn, forceRun=True)
+        assert len(coll.fqns()) > 0
+
+        # if we run again the collector should be empty because all
+        # module results have been persisted so there would be no run
+        # info collected
+        res, coll = self.smvApp.runModule(self.urn, forceRun=False)
+        assert len(coll.fqns()) == 0
+
+    def test_get_run_info_is_empty_if_no_module_is_run(self):
+        coll = self.smvApp.getRunInfo(self.urn)
+        assert len(coll.fqns()) > 0  # still collected the dependencies
+
+        for fqn in coll.fqns():
+            assert len(coll.dqm_validation(fqn)) == 0
+            assert len(coll.dqm_state(fqn)) == 0
+            assert len(coll.metadata(fqn)) == 0
+            assert len(coll.metadata_history(fqn)) == 0
+
+    def test_get_run_info_should_return_info_from_last_run(self):
+        self.smvApp.runModule(self.urn, forceRun=True)
+        self.smvApp.runModule(self.urn, forceRun=False)
+        coll = self.smvApp.getRunInfo(self.urn)
+        for fqn in coll.fqns():
+            if 'R2' not in fqn:  # R2 module does not have validation
+                assert len(coll.dqm_validation(fqn)) > 0
+                assert len(coll.dqm_state(fqn)) > 0

--- a/src/test/python/testSmvRunInfo/stage/modules.py
+++ b/src/test/python/testSmvRunInfo/stage/modules.py
@@ -1,0 +1,49 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from smv import SmvCsvStringData
+from smv import SmvModule
+
+
+class R0(SmvCsvStringData):
+    def schemaStr(self):
+        return "a:String;b:Integer"
+
+
+class R1(R0):
+    def dataStr(self):
+        return "x,1;y,2"
+
+
+class R2(SmvModule):
+    def requiresDS(self):
+        return [R1]
+
+    def run(self, i):
+        return i[R1]
+
+
+class R3(R0):
+    def requiresDS(self):
+        return [R1]
+
+    def dataStr(self):
+        return "l,2;m,3;n,5;"
+
+
+class R4(R0):
+    def requiresDS(self):
+        return [R2, R3]
+
+    def dataStr(self):
+        return "l,2;m,3;n,5;"


### PR DESCRIPTION
Close #1086 

#### New API
- SmvApp::getRunInfo(urn) -> SmvRunInfoCollector

If the module has never been run, returns a collector with all the dependencies but no information (i.e. an empty collector)

If the module has been run, returns a collector with the run information from the last run for the module and all dependencies (including transitive ones)