### PR TITLE
I1105 get run info in shell

### DIFF
--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -16,8 +16,8 @@
 Todo:
     * document example use
 """
-
 import json
+from pprint import pformat
 
 
 class SmvRunInfoCollector(object):
@@ -101,3 +101,15 @@ class SmvRunInfoCollector(object):
         if java_result is None:
             return {}
         return json.loads(java_result.toJson())
+
+    def show_report(self):
+        msg = 'datasets: %s' % self.fqns()
+        for fqn in self.fqns():
+            msg += '\n+ %s' % fqn
+            msg += '\n|- dqm validation:'
+            msg += '\n     ' + pformat(self.dqm_validation(fqn), indent=5)
+            msg += '\n|- metadata:'
+            msg += '\n     ' + pformat(self.metadata(fqn), indent=5)
+            msg += '\n|- metadata history:'
+            msg += '\n     ' + pformat(self.metadata_history(fqn), indent=5)
+        print msg

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -229,11 +229,37 @@ class SmvApp(object):
         SmvRunInfoCollector returned from this method would contain
         all latest run information about all dependent modules.
 
+        Args:
+            urn (str): urn of target module
+
         Returns:
             SmvRunInfoCollector
 
         """
         java_result = self.j_smvPyClient.getRunInfo(urn)
+        return SmvRunInfoCollector(java_result)
+
+    def getRunInfoByPartialName(self, name):
+        """Returns the run information of a module and all its dependencies
+        from the last run.
+
+        Unlike the runModule() method, which returns the run
+        information just for that run, this method returns the run
+        information from the last run.
+
+        If no module was run (e.g. the code did not change, so the
+        data is read from persistent storage), the SmRunInfoCollector
+        returned from the runModule() method would be empty.  But the
+        SmvRunInfoCollector returned from this method would contain
+        all latest run information about all dependent modules.
+
+        Args:
+            name (str): unique suffix to fqn of target module
+
+        Returns:
+            SmvRunInfoCollector
+        """
+        java_result = self.j_smvPyClient.getRunInfoByPartialName(name)
         return SmvRunInfoCollector(java_result)
 
     def getMetadataJson(self, urn):

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -275,15 +275,12 @@ def _clear_from_sys_modules(names_to_clear):
 
 def show_run_info(collector):
     """Inspects the SmvRunInfoCollector object returned by smvApp.runModule"""
-    print('datasets: %s' % collector.fqns())
-    for fqn in collector.fqns():
-        print('+ %s' % fqn)
-        print('|- dqm validation:')
-        print('    ' + pformat(collector.dqm_validation(fqn), indent=5))
-        print('|- metadata:')
-        print('     ' + pformat(collector.metadata(fqn), indent=5))
-        print('|- metadata history:')
-        print('     ' + pformat(collector.metadata_history(fqn), indent=5))
+    collector.show_report()
+
+def get_run_info(name):
+    """Get the SmvRunInfoCollector with full information about a module and its dependencies
+    """
+    return SmvApp.getInstance().getRunInfoByPartialName(name)
 
 __all__ = [
     'df',
@@ -306,5 +303,6 @@ __all__ = [
     'smvDiscoverSchemaToFile',
     'edd',
     'run_test',
-    'show_run_info'
+    'show_run_info',
+    'get_run_info'
 ]

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -515,8 +515,8 @@ abstract class SmvDataSet extends FilenamePart {
    */
   def runInfo: SmvRunInfo = {
     val validation = DQMValidator.readPersistedValidationFile(moduleValidPath()).toOption.orNull
-    val meta = readPersistedMetadata(moduleMetaPath()).toOption.orNull
-    val mhistory = readMetadataHistory(moduleMetaHistoryPath()).toOption.orNull
+    val meta = readPersistedMetadata().toOption.orNull
+    val mhistory = readMetadataHistory().toOption.orNull
     SmvRunInfo(validation, meta, mhistory)
   }
 


### PR DESCRIPTION
Resolves #1105. Also noticed and fixed a bug that was causing `SmvApp.getRunInfo` to return an empty RunInfo even thought there was metadata and validation data available.