### PR TITLE
I1099 publish to hive method

### DIFF
--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -262,6 +262,11 @@ class SmvApp(object):
         java_result = self.j_smvPyClient.getRunInfoByPartialName(name)
         return SmvRunInfoCollector(java_result)
 
+    def publishModuleToHiveByName(self, name, runConfig=None):
+        """Publish an SmvModule to Hive by its name (can be partial FQN)
+        """
+        return self.j_smvPyClient.publishModuleToHiveByName(name, runConfig)
+
     def getMetadataJson(self, urn):
         """Returns the metadata for a given urn"""
         return self.j_smvPyClient.getMetadataJson(urn)

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -170,13 +170,13 @@ def lsDeadLeaf(stageName = None):
     else:
         print(_jvmShellCmd().lsDeadLeaf(stageName))
 
-def exportToHive(dsname):
+def exportToHive(dsname, runConfig=None):
     """Export dataset's running result to a Hive table
 
         Args:
             dsname (str): The name of an SmvDataSet
     """
-    print(_jvmShellCmd().exportToHive(dsname))
+    SmvApp.getInstance().publishModuleToHiveByName(dsname, runConfig)
 
 def ancestors(dsname):
     """List all ancestors of a dataset

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -373,6 +373,14 @@ class SmvApp(private val cmdLineArgs: Seq[String],
     val ds = dsm.inferDS(modName).head
     runDS(ds, forceRun, version, runConfig, collector=collector)
   }
+  
+  def publishModuleToHiveByName(modName: String,
+                                runConfig: Map[String, String],
+                                collector: SmvRunInfoCollector): Unit = {
+      val ds = dsm.inferDS(modName).head
+      setDynamicRunConfig(runConfig)
+      ds.exportToHive(collector)
+  }
 
   def getRunInfo(partialName: String): SmvRunInfoCollector =
     getRunInfo(dsm.inferDS(partialName).head)

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -373,13 +373,12 @@ class SmvApp(private val cmdLineArgs: Seq[String],
     val ds = dsm.inferDS(modName).head
     runDS(ds, forceRun, version, runConfig, collector=collector)
   }
-  
+
   def publishModuleToHiveByName(modName: String,
                                 runConfig: Map[String, String],
                                 collector: SmvRunInfoCollector): Unit = {
-      val ds = dsm.inferDS(modName).head
       setDynamicRunConfig(runConfig)
-      ds.exportToHive(collector)
+      dsm.inferDS(modName).head.exportToHive(collector)
   }
 
   def getRunInfo(partialName: String): SmvRunInfoCollector =

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -273,6 +273,13 @@ class SmvPyClient(val j_smvApp: SmvApp) {
     RunModuleResult(df, collector)
   }
 
+  def publishModuleToHiveByName(name: String,
+                                runConfig: java.util.Map[String, String]) = {
+      val dynamicRunConfig: Map[String, String] = if (null == runConfig) Map.empty else mapAsScalaMap(runConfig).toMap
+      val collector = new SmvRunInfoCollector
+      j_smvApp.publishModuleToHiveByName(name, dynamicRunConfig, collector)
+  }
+
   /**
    * Returns the run information of a dataset and all its dependencies
    * from the last run.

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -157,8 +157,10 @@ object ShellCmd {
   /**
    * Export dataset's running result to a Hive table
   **/
-  def exportToHive(dsName: String, collector: SmvRunInfoCollector=new SmvRunInfoCollector) = {
-    dsm.inferDS(dsName).head.exportToHive(collector=collector)
+  def exportToHive(dsName: String,
+                   runConfig: Map[String, String] = Map.empty,
+                   collector: SmvRunInfoCollector=new SmvRunInfoCollector) = {
+    SmvApp.app.publishModuleToHiveByName(dsName, runConfig, collector)
   }
 
   /**


### PR DESCRIPTION
Resolves #1099. As a bonus, I fixed the pyshell function `exportToHive`, which was calling the Scala `exportToHive` with the wrong args. The Scala args had changed after the SmvRunInfoCollector was added. Also gave `exportToHive` a `runConfig` arg.