### PR TITLE
Fixed smvExportCsv not working form shell

### DIFF
--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -94,7 +94,7 @@ def smvExportCsv(name, path):
             fqn (str): the name of the module
             path (str): a path on the local file system
     """
-    _jvmShellCmd().smvExportCsv(name, path)
+    _jvmShellCmd().smvExportCsv(name, path, None)
 
 def help():
     """Print a list of the SMV helper functions available in the shell

--- a/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
+++ b/src/main/scala/org/tresamigos/smv/shell/ShellCmd.scala
@@ -179,6 +179,7 @@ object ShellCmd {
 
   /**
    * Deprecated
+   * ShellCmd.smvExportCsv should use SmvDFHelper.smvExportCsv (#884)
    */
   def smvExportCsv(name: String, path: String, collector: SmvRunInfoCollector=new SmvRunInfoCollector) = {
     println("The smvExportCsv shell method is deprecated")


### PR DESCRIPTION
Fixes #1109 

The problem seems to be that py4j does recognize functions with optional parameters. Therefore optional parameter functions must be explicitly passed a `None` (or some other) value.
Other functions such as `exportToHive` are also broken.

I'm submitting this PR for initial review, about how this was fixed. But I think we should also fix other functions that are not working  for the same reason, in this ticket.