### PR TITLE
I1126 - Update --driver-class-path to also supply a relative path, add support for `=` options when merging props

### DIFF
--- a/tools/_env.sh
+++ b/tools/_env.sh
@@ -32,17 +32,33 @@ function split_smv_spark_args()
 
     # Need to extract the --jars option so we can concatenate those jars with
     # the APP_JAR when we run the spark-submit. Spark will not accept 2 separate
-    # --jars options
+    # --jars options. Also need to handle the case when user uses equal signs (--jars=xyz.jar)
+    # Same for --driver-class-path
     while [ $# -ne 0 ]; do
         if [ "$1" == "--jars" ]; then
             shift
             EXTRA_JARS="$1"
+            shift
+        # See http://wiki.bash-hackers.org/syntax/pe#search_and_replace for bash string parsing
+        # tricks
+        elif [ ${1%%=*} == "--jars" ]; then
+            local ACTUAL_JARS_PORTION="${1#*=}"
+            EXTRA_JARS="${ACTUAL_JARS_PORTION}"
+            # Only need to shift once since we dont have a space separator
+            shift
+        elif [ "$1" == "--driver-class-path" ]; then
+            EXTRA_DRIVER_CLASSPATHS="$1"
+        elif [ ${1%%=*} == "--driver-class-path" ]; then
+            local ACTUAL_CLASSPATHS_PORTION="${1#*=}"
+            EXTRA_DRIVER_CLASSPATHS="${ACTUAL_CLASSPATHS_PORTION}"
+            # Only need to shift once since we dont have a space separator
             shift
         else
           SPARK_ARGS=("${SPARK_ARGS[@]}" "$1")
           shift
         fi
     done
+
 }
 
 function find_file_in_dir()

--- a/tools/_pyenv.sh
+++ b/tools/_pyenv.sh
@@ -13,6 +13,12 @@ export PYTHONPATH="$SMV_HOME/src/main/python:$PYTHONPATH"
 export PYTHONDONTWRITEBYTECODE=1
 export SPARK_PRINT_LAUNCH_COMMAND=1
 
+# We eagerly add the basename of the APP_JAR so that this same command
+# works in YARN Cluster mode, where the JAR gets added to the root directory
+# of the container. Also note the colon separator
 function run_pyspark_with () {
-  "${SMV_SPARK_SUBMIT_FULLPATH}" "${SPARK_ARGS[@]}" --jars "$APP_JAR,$EXTRA_JARS" --driver-class-path "$APP_JAR" $1 "${SMV_ARGS[@]}"
+  "${SMV_SPARK_SUBMIT_FULLPATH}" "${SPARK_ARGS[@]}" \
+    --jars "$APP_JAR,$EXTRA_JARS" \
+    --driver-class-path "$APP_JAR:$(basename ${APP_JAR}):$EXTRA_DRIVER_CLASSPATHS" \
+    $1 "${SMV_ARGS[@]}"
 }


### PR DESCRIPTION
Greater flexibility for supplying --jars, and support for merging --driver-class-path spark argument

Before we did not handle the case of when --option=abc with an equals sign. Additionally, when we ran in cluster mode, the absolute path supplied to --driver-class-path did not work since the JAR is placed by Spark at the root of the YARN container, and therefore needs to be referenced by relative path.

Closes #1126 