### PR TITLE
pass port, ip to jupyter directly

### DIFF
--- a/docker/smv/jupyter_notebook_config.py
+++ b/docker/smv/jupyter_notebook_config.py
@@ -1,9 +1,9 @@
 import os
 
-## The IP address the notebook server will listen on.
+## Default value for IP address the notebook server will listen on. Will be overriden by command line
 c.NotebookApp.ip = os.environ.get('JUPYTER_IP', '*')
 
-## The port the notebook server will listen on.
+## Deafult port for the notebook server will listen on. Will be overriden by command line
 c.NotebookApp.port = int(os.environ.get('JUPYTER_PORT', '8888'))
 
 ## Disable authentication

--- a/tools/smv-jupyter
+++ b/tools/smv-jupyter
@@ -4,24 +4,33 @@ set -e
 
 SMV_TOOLS="$(cd "`dirname "$0"`"; pwd)"
 
-# extract --ip/--port options (must be in that order) from command line.
-# sets JUPYTER_IP/JUPYTER_PORT which will be read in jupyter_notebook_config.py
-if [ "$1" = "--ip" ]; then
-  export JUPYTER_IP="$2"
-  shift; shift
-fi
-if [ "$1" = "--port" ]; then
-  export JUPYTER_PORT="$2"
-  shift; shift
-fi
-
 export PYSPARK_DRIVER_PYTHON="$(which jupyter)"
 
 if [ -f "${HOME}/.jupyter/jupyter_notebook_config.py" ]; then
-  export PYSPARK_DRIVER_PYTHON_OPTS="notebook"
+  pyspark_driver_python_opts="notebook"
 else
-  export PYSPARK_DRIVER_PYTHON_OPTS="notebook --FileContentsManager.root_dir=notebooks --NotebookApp.open_browser=False"
+  pyspark_driver_python_opts="notebook --FileContentsManager.root_dir=notebooks --NotebookApp.open_browser=False"
 fi
+
+extra_args=''
+
+# extract --ip/--port options (must be in that order) from command line.
+# sets JUPYTER_IP/JUPYTER_PORT which will be read in jupyter_notebook_config.py
+if [ "$1" = "--ip" ]; then
+  jupyter_ip="$2"
+  extra_args+=" --NotebookApp.ip=$jupyter_ip"
+  shift; shift
+fi
+if [ "$1" = "--port" ]; then
+  jupyter_port="$2"
+  # set port retries to 0 so that the process exits with non-zero exit code instead of
+  # default behaviour of retrying random ports if port is occupied
+  extra_args+=" --NotebookApp.port=$jupyter_port --NotebookApp.port_retries=0"
+  shift; shift
+fi
+
+export PYSPARK_DRIVER_PYTHON_OPTS="$pyspark_driver_python_opts $extra_args"
+echo "Exporting $PYSPARK_DRIVER_PYTHON_OPTS"
 
 # Pass through the options from `smv-jupyter` invocation through to `smv-pyshell`
 # This will allow the user to specify pyspark options like:


### PR DESCRIPTION
Fixes  #1133

**Warning:** I changed the behaviour of `--port` so that instead of retrying random ports if the port is occupied, the process exits with a non-zero exit code. This interface is much better for programmatic control, but if there is some reason we want the other option, I can make this behavior depend on a separate flag.