### PR TITLE
Fix datasetrepos ability to clear mods for multipart stages

### DIFF
--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -45,10 +45,24 @@ class DataSetRepo(object):
     def _clear_sys_modules(self):
         """Clear all client modules from sys.modules
         """
-        for fqn in list(sys.modules.keys()):
-            for stage_name in self.smvApp.stages():
-                if fqn == stage_name or fqn.startswith(stage_name + "."):
-                    sys.modules.pop(fqn)
+        # First, we assemble a list of fqn stubs we want to clear from the sys.modules
+        # If stage name is like appname.stagename, we want list('appname', 'appname.stagename')
+
+        # this adds the full stage names to the list
+        fqn_stubs_to_remove = list(self.smvApp.stages())
+
+        # now iterate through full names like 'airlineapp.etl', 'foo.bar' and append the prefix ie: 'foo'
+        # to our list of py modules to remove
+        for stage_name in self.smvApp.stages():
+            stage_name_stub = stage_name.split('.')[0]
+            if stage_name_stub not in fqn_stubs_to_remove:
+                fqn_stubs_to_remove.append(stage_name_stub)
+
+        # iterate through the loaded modules and remove them if there's a match in the above list
+        for loaded_mod_fqn in list(sys.modules.keys()):
+            for stage_name_or_stub in fqn_stubs_to_remove:
+                if loaded_mod_fqn == stage_name_or_stub or loaded_mod_fqn.startswith(stage_name_or_stub + "."):
+                    sys.modules.pop(loaded_mod_fqn)
                     break
 
     # Implementation of IDataSetRepoPy4J loadDataSet, which loads the dataset


### PR DESCRIPTION
Fixes #1144

My approach is to assemble a list of stages and stage stubs that need to be removed and then iterate all of the loaded modules and to use the existing criteria to try to remove the fqn from `sys.modules`.

Also, I extensively renamed stuff to (hopefully) make more sense.