### PR TITLE
I989 better logging

### DIFF
--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -125,19 +125,19 @@ class DataSetRepo(object):
     def _dataSetsForStage(self, stageName):
         urns = []
 
+        self.smvApp.log.debug("Searching for SmvDataSets in stage " + stageName)
+        self.smvApp.log.debug("sys.path=" + repr(sys.path))
+
         for pymod_name in self._iter_submodules([stageName]):
             # The additional "." is necessary to prevent false positive, e.g. stage_2.M1 matches stage
             if pymod_name.startswith(stageName + "."):
-                self.smvApp.log.debug("Search for SmvDataSets in " + pymod_name)
-
                 # __import__('a.b.c') returns the module a, just like import a.b.c
                 pymod = __import__(pymod_name)
                 # After import a.b.c we got a. Now we traverse from a to b to c
                 for c in pymod_name.split('.')[1:]:
                     pymod = getattr(pymod, c)
 
-                self.smvApp.log.debug("Searching for SmvDataSets in {} which is "
-                                      "located at {}".format(pymod_name, pymod.__file__))
+                self.smvApp.log.debug("Searching for SmvDataSets in " + repr(pymod))
 
                 # iterate over the attributes of the module, looking for SmvDataSets
                 for obj_name in dir(pymod):

--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -10,13 +10,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
+import inspect
+import pkgutil
 import sys
 import traceback
-import pkgutil
-import inspect
 
 from smv.error import SmvRuntimeError
-from smv.utils import for_name, smv_copy_array, iter_submodules
+from smv.utils import smv_copy_array
 from smv.py4j_interface import create_py4j_interface_method
 
 """Python implementations of IDataSetRepoPy4J and IDataSetRepoFactoryPy4J interfaces
@@ -51,6 +52,53 @@ class DataSetRepo(object):
                     sys.modules.pop(fqn)
                     break
 
+    def _iter_submodules(self, stages):
+        """Yield the names of all submodules of the packages corresponding to the given stages
+        """
+        file_iters_by_stage = (self._iter_submodules_in_stage(stage) for stage in stages)
+        file_iter = itertools.chain(*file_iters_by_stage)
+        return (name for (_, name, is_pkg) in file_iter if not is_pkg)
+
+    def _iter_submodules_in_stage(self, stage):
+        """Yield info on the submodules of the package corresponding with a given stage
+        """
+        try:
+            stagemod = __import__(stage)
+        except:
+            self.smvApp.log.warn("Package does not exist for stage: " + stage)
+            return []
+        # `walk_packages` can generate AttributeError if the system has
+        # Gtk modules, which are not designed to use with reflection or
+        # introspection. Best action to take in this situation is probably
+        # to simply suppress the error.
+        def onerror(name):
+            self.smvApp.log.error("Skipping due to error during walk_packages: " + name)
+        return pkgutil.walk_packages(stagemod.__path__, stagemod.__name__ + '.' , onerror=onerror)
+
+    def _for_name(self, name):
+        """Dynamically load a module in a stage by its name.
+
+            Similar to Java's Class.forName, but only looks in configured stages.
+        """
+        lastdot = name.rfind('.')
+        file_name = name[ : lastdot]
+        mod_name = name[lastdot+1 : ]
+
+        mod = None
+
+        # if file doesnt exist, module doesn't exist
+        if file_name in self._iter_submodules(self.smvApp.stages):
+            # __import__ instantiates the module hierarchy but returns the root module
+            f = __import__(file_name)
+            # iterate to get the file that should contain the desired module
+            for subname in file_name.split('.')[1:]:
+                f = getattr(f, subname)
+            # leave mod as None if the file exists but doesnt have an attribute with that name
+            if hasattr(f, mod_name):
+                mod = getattr(f, mod_name)
+
+        return mod
+
     # Implementation of IDataSetRepoPy4J loadDataSet, which loads the dataset
     # from the most recent source. If the dataset does not exist, returns None.
     # However, if there is an error (such as a SyntaxError) which prevents the
@@ -58,7 +106,7 @@ class DataSetRepo(object):
     # DataSetRepoPython.
     def loadDataSet(self, fqn):
         ds = None
-        ds_class = for_name(fqn, self.smvApp.stages)
+        ds_class = self._for_name(fqn)
 
         if ds_class is not None:
             ds = ds_class(self.smvApp)
@@ -76,37 +124,69 @@ class DataSetRepo(object):
 
     def _dataSetsForStage(self, stageName):
         urns = []
-        # import the stage and only walk the packages in the path of that stage, recursively
-        for name in iter_submodules([stageName]):
-                # The additional "." is necessary to prevent false positive, e.g. stage_2.M1 matches stage
-                if name.startswith(stageName + "."):
-                    # __import__('a.b.c') returns the module a, just like import a.b.c
-                    pymod = __import__(name)
-                    # after import 'a.b.c' we got a, traverse from a to b to c
-                    for c in name.split('.')[1:]:
-                        pymod = getattr(pymod, c)
 
-                    # iterate over the attributes of the module, looking for SmvDataSets
-                    for n in dir(pymod):
-                        obj = getattr(pymod, n)
-                        # We try to access the IsSmvDataSet attribute of the object.
-                        # if it does not exist, we will catch the the AttributeError
-                        # and skip the object, as it is not an SmvDataSet. We
-                        # specifically check that IsSmvDataSet is identical to
-                        # True, because some objects like Py4J's JavaObject override
-                        # __getattr__ to **always** return something (so IsSmvDataSet
-                        # maybe truthy even though the object is not an SmvDataSet).
-                        try:
-                            obj_is_smv_dataset = (obj.IsSmvDataSet is True)
-                        except AttributeError:
-                            continue
-                        # Class should have an fqn which begins with the stageName.
-                        # Each package will contain among other things all of
-                        # the modules that were imported into it, and we need
-                        # to exclude these (so that we only count each module once)
-                        # Also we need to exclude ABCs
-                        if obj_is_smv_dataset and obj.fqn().startswith(name) and not inspect.isabstract(obj):
-                            urns.append(obj.urn())
+        for pymod_name in self._iter_submodules([stageName]):
+            # The additional "." is necessary to prevent false positive, e.g. stage_2.M1 matches stage
+            if pymod_name.startswith(stageName + "."):
+                self.smvApp.log.debug("Search for SmvDataSets in " + pymod_name)
+
+                # __import__('a.b.c') returns the module a, just like import a.b.c
+                pymod = __import__(pymod_name)
+                # After import a.b.c we got a. Now we traverse from a to b to c
+                for c in pymod_name.split('.')[1:]:
+                    pymod = getattr(pymod, c)
+
+                self.smvApp.log.debug("Searching for SmvDataSets in {} which is "
+                                      "located at {}".format(pymod_name, pymod.__file__))
+
+                # iterate over the attributes of the module, looking for SmvDataSets
+                for obj_name in dir(pymod):
+                    obj = getattr(pymod, obj_name)
+                    self.smvApp.log.debug("Inspecting {} ({})".format(obj_name, type(obj)))
+                    # We try to access the IsSmvDataSet attribute of the object.
+                    # if it does not exist, we will catch the the AttributeError
+                    # and skip the object, as it is not an SmvDataSet. We
+                    # specifically check that IsSmvDataSet is identical to
+                    # True, because some objects like Py4J's JavaObject override
+                    # __getattr__ to **always** return something (so IsSmvDataSet
+                    # maybe truthy even though the object is not an SmvDataSet).
+                    try:
+                        obj_is_smv_dataset = (obj.IsSmvDataSet is True)
+                    except AttributeError:
+                        obj_is_smv_dataset = False
+
+                    if not obj_is_smv_dataset:
+                        self.smvApp.log.debug("Ignoring {} because it is not an "
+                                              "SmvDataSet".format(obj_name))
+                        continue
+
+                    # Class should have an fqn which begins with the stageName.
+                    # Each package will contain all of the modules, classes, etc.
+                    # that were imported into it, and we need to exclude these
+                    # (so that we only count each module once)
+                    obj_declared_in_stage = obj.fqn().startswith(pymod_name)
+
+                    if not obj_declared_in_stage:
+                        self.smvApp.log.debug("Ignoring {} because it was not "
+                                              "declared in {}. (Note: it may "
+                                              "be collected from another stage)"
+                                              .format(obj_name, pymod_name))
+                        continue
+
+                    # Class should not be an ABC
+                    obj_is_abstract = inspect.isabstract(obj)
+
+                    if obj_is_abstract:
+                        # abc labels methods as abstract via the attribute __isabstractmethod__
+                        is_abstract_method = lambda attr: getattr(attr, "__isabstractmethod__", False)
+                        abstract_methods = [name for name, _ in inspect.getmembers(obj, is_abstract_method)]
+                        self.smvApp.log.debug("Ignoring {} because it is abstract ({} undefined)"
+                                              .format(obj_name, ", ".join(abstract_methods)))
+
+                        continue
+
+                    self.smvApp.log.debug("Collecting " + obj_name)
+                    urns.append(obj.urn())
 
         return urns
 

--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -100,7 +100,14 @@ class SmvRunInfoCollector(object):
         java_result = self.jcollector.getMetadataHistory(dsFqn)
         if java_result is None:
             return {}
-        return json.loads(java_result.toJson())
+        # note that the json is an object with the structure
+        # {
+        #   "history": [
+        #     {...},
+        #     ...   
+        #   ]
+        # }
+        return json.loads(java_result.toJson())['history']
 
     def show_report(self):
         msg = 'datasets: %s' % self.fqns()

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -404,10 +404,12 @@ class SmvApp(object):
         abs_path = self.abs_path_for_project_path(project_path)
         # Source must be added to front of path to make sure it is found first
         sys.path.insert(1, abs_path)
+        self.log.debug("Prepended {} to sys.path".format(abs_path))
 
     def remove_source(self, project_path):
         abs_path = self.abs_path_for_project_path(project_path)
         sys.path.remove(abs_path)
+        self.log.debug("Removed {} from sys.path".format(abs_path))
 
     def run(self):
         self.j_smvApp.run()

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -90,7 +90,7 @@ class SmvApp(object):
 
         # shortcut is meant for internal use only
         self.j_smvApp = self.j_smvPyClient.j_smvApp()
-
+        self.log = self.j_smvApp.log()
         self.stages = self.j_smvPyClient.stages()
 
         # issue #429 set application name from smv config

--- a/src/main/python/smv/utils.py
+++ b/src/main/python/smv/utils.py
@@ -16,51 +16,6 @@ from pyspark.sql import DataFrame
 import itertools
 import pkgutil
 
-def iter_submodules(stages):
-    """Yield the names of all submodules of the packages corresponding to the given stages
-    """
-    file_iters_by_stage = (iter_submodules_in_stage(stage) for stage in stages)
-    file_iter = itertools.chain(*file_iters_by_stage)
-    return (name for (_, name, is_pkg) in file_iter if not is_pkg)
-
-def iter_submodules_in_stage(stage):
-    """Yield info on the submodules of the package corresponding with a given stage
-    """
-    try:
-        stagemod = __import__(stage)
-    except:
-        return []
-    # `walk_packages` can generate AttributeError if the system has
-    # Gtk modules, which are not designed to use with reflection or
-    # introspection. Best action to take in this situation is probably
-    # to simply suppress the error.
-    def onerror(n): pass
-    return pkgutil.walk_packages(stagemod.__path__, stagemod.__name__ + '.' , onerror=onerror)
-
-def for_name(name, stages):
-    """Dynamically load a module in a stage by its name.
-
-        Similar to Java's Class.forName, but only looks in configured stages.
-    """
-    lastdot = name.rfind('.')
-    file_name = name[ : lastdot]
-    mod_name = name[lastdot+1 : ]
-
-    mod = None
-
-    # if file doesnt exist, module doesn't exist
-    if file_name in iter_submodules(stages):
-        # __import__ instantiates the module hierarchy but returns the root module
-        f = __import__(file_name)
-        # iterate to get the file that should contain the desired module
-        for subname in file_name.split('.')[1:]:
-            f = getattr(f, subname)
-        # leave mod as None if the file exists but doesnt have an attribute with tha name
-        if hasattr(f, mod_name):
-            mod = getattr(f, mod_name)
-
-    return mod
-
 
 def smv_copy_array(sc, *cols):
     """Copy Python list to appropriate Java array

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -14,6 +14,8 @@
 
 package org.tresamigos.smv
 
+import org.apache.log4j.LogManager
+
 import org.tresamigos.smv.util.Edd
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -34,7 +36,7 @@ import org.joda.time.DateTime
 class SmvApp(private val cmdLineArgs: Seq[String],
              _sc: Option[SparkContext] = None,
              _sql: Option[SQLContext] = None) {
-
+  val log         = LogManager.getLogger("smv")
   val smvConfig   = new SmvConfig(cmdLineArgs)
   val genEdd      = smvConfig.cmdLine.genEdd()
   val publishHive = smvConfig.cmdLine.publishHive()

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -181,7 +181,7 @@ abstract class SmvDataSet extends FilenamePart {
       queries foreach {app.sqlContext.sql(_)}
     }
 
-    logAction(f"PUBLISHING ${fqn} TO HIVE: ${queries.mkString(";")}", _export)
+    doAction(f"PUBLISHING ${fqn} TO HIVE: ${queries.mkString(";")}", _export)
 
   }
 
@@ -314,7 +314,10 @@ abstract class SmvDataSet extends FilenamePart {
                attr: CsvAttributes = CsvAttributes.defaultCsv): DataFrame =
     new FileIOHandler(app.sqlContext, path).csvFileWithSchema(attr)
 
-  def logAction(desc: String, action: () => Unit): Unit = {
+  /**
+   * Perform an action and log the amount of time it took
+   */
+  def doAction(desc: String, action: () => Unit): Unit = {
     app.log.info(f"${desc}")
     val before  = DateTime.now()
 
@@ -334,7 +337,7 @@ abstract class SmvDataSet extends FilenamePart {
 
     def _persist = () => handler.saveAsCsvWithSchema(df, strNullValue = "_SmvStrNull_")
 
-    logAction(f"PERSISTING OUTPUT: ${path}", _persist)
+    doAction(f"PERSISTING OUTPUT: ${path}", _persist)
 
     val n       = counter.value
     app.log.info(f"N: ${n}")
@@ -470,7 +473,7 @@ abstract class SmvDataSet extends FilenamePart {
   private[smv] def persistMetadata(metadata: SmvMetadata): Unit = {
     val metaPath =  moduleMetaPath()
     def _persistMetadata() = metadata.saveToFile(app.sc, metaPath)
-    logAction(f"PERSISTING METADATA: ${metaPath}", _persistMetadata)
+    doAction(f"PERSISTING METADATA: ${metaPath}", _persistMetadata)
   }
   /**
    * Maximum of the metadata history
@@ -487,7 +490,7 @@ abstract class SmvDataSet extends FilenamePart {
       oldHistory
         .update(metadata, metadataHistorySize)
         .saveToFile(app.sc, metaHistoryPath)
-    logAction(f"PERSISTING METADATA HISTORY: ${metaHistoryPath}", _peristMetaHistory)
+    doAction(f"PERSISTING METADATA HISTORY: ${metaHistoryPath}", _peristMetaHistory)
   }
   /**
    * Override to validate module results based on current and historic metadata.

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -161,7 +161,7 @@ abstract class SmvDataSet extends FilenamePart {
    */
   def exportToHive(collector: SmvRunInfoCollector) = {
     val dataframe = rdd(collector=collector)
-    
+
     // register the dataframe as a temp table.  Will be overwritten on next register.
     dataframe.registerTempTable("dftable")
 
@@ -429,11 +429,14 @@ abstract class SmvDataSet extends FilenamePart {
     val resMetadata = dfOpt match {
       case Some(df) => {
         // updated cached user metadata if it was not already computed.
-        userMetadataCache = userMetadataCache match {
-          case None => Option(metadata(df))
-          case _ => userMetadataCache
+        userMetadataCache match {
+          case Some(meta) => meta
+          case None => {
+            app.log.info(f"GENERATING USER METADATA: ${fqn}")
+            userMetadataCache = Some(metadata(df))
+            userMetadataCache.get
+          }
         }
-        userMetadataCache.get
       }
       case _ => new SmvMetadata()
     }


### PR DESCRIPTION
I don't think this fully resolves #989, because I haven't figured out why the smv logger doesn't seem to inherit the root loggers level. I'd like to merge in this logging in the meantime. 

Note that I've moved the tools for package introspection from `smv.utils` into the `DataSetRepo` class, because that was the only place they were used and logging from them was easier this way.