### PR TITLE
i1155 keep help shell function up to date automatically

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,8 @@ parallelExecution in Test := false
 
 publishArtifact in Test := true
 
+envVars in Test := Map("SMV_HOME" -> ".")
+
 // Create itest task that runs integration tests
 val itest = TaskKey[Unit]("itest", "Run Integration Test")
 itest := {

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -12,15 +12,17 @@
 # limitations under the License.
 """Helper functions available in SMV's Python shell
 """
+import re
 import sys
-from pprint import pformat
+
+from inspect import formatargspec, getargspec
 
 from smv import SmvApp
-from pyspark.sql import DataFrame
-
-from smv import CsvAttributes
 from test_support.test_runner import SmvTestRunner
 from test_support.testconfig import TestConfig
+
+from pyspark.sql import DataFrame
+
 
 def _jvmShellCmd():
     return SmvApp.getInstance()._jvm.org.tresamigos.smv.shell.ShellCmd
@@ -111,32 +113,18 @@ def smvExportCsv(name, path):
 def help():
     """Print a list of the SMV helper functions available in the shell
     """
-    import re
-    strip_margin = lambda text: re.sub('\n[ \t]*\|', '\n', text)
+    this_mod = sys.modules[__name__]
 
-    help_msg = strip_margin(
-     """Here is a list of SMV-shell command
-       |
-       |Please refer to the API doc for details:
-       |https://github.com/TresAmigosSD/SMV/blob/master/docs/user/run_shell.md
-       |
-       |  * lsStage()
-       |  * ls()
-       |  * ls(stageName)
-       |  * lsDead()
-       |  * lsDead(stageName)
-       |  * lsDeadLeaf()
-       |  * lsDeadLeaf(stageName)
-       |  * props()
-       |  * exportToHive(datasetName)
-       |  * graph()
-       |  * graph(stageName)
-       |  * ancestors(datasetName)
-       |  * descendants(datasetName)
-       |  * now()
-       |  * smvDiscoverSchemaToFile(filePath)
-       """
-    )
+    help_msg = "SMV shell commands:"
+    for func_name in __all__:
+        func = getattr(this_mod, func_name)
+        signature = formatargspec(*getargspec(func))
+        help_msg += "\n* {}{}".format(func_name, signature)
+
+    smv_version = SmvApp.getInstance().j_smvApp.smvVersion()
+    doc_url = ("http://tresamigossd.github.io/SMV/pythondocs/{}/smv.html#module-smv.smvshell"
+                .format(smv_version))
+    help_msg += "\nDocumentation may be found at " + doc_url
 
     print(help_msg)
 

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -47,7 +47,7 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   val sparkConf   = new SparkConf().setAppName(smvConfig.appName)
 
   val smvVersion  = {
-    val smvHome = sys.env.getOrElse("SMV_HOME", ".")
+    val smvHome = sys.env("SMV_HOME")
     val versionFile = Source.fromFile(f"${smvHome}/.smv_version")
     val nextLine = versionFile.getLines.next
     versionFile.close

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -47,7 +47,8 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   val sparkConf   = new SparkConf().setAppName(smvConfig.appName)
 
   val smvVersion  = {
-    val versionFile = Source.fromFile(f"${sys.env("SMV_HOME")}/.smv_version")
+    val smvHome = sys.env.getOrElse("SMV_HOME", ".")
+    val versionFile = Source.fromFile(f"${smvHome}/.smv_version")
     val nextLine = versionFile.getLines.next
     versionFile.close
   }

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -14,19 +14,20 @@
 
 package org.tresamigos.smv
 
+
+import collection.JavaConverters._
+import java.util.List
+import scala.collection.mutable
+import scala.io.Source
+import scala.util.{Try, Success, Failure}
+
 import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.{SparkContext, SparkConf}
+import org.joda.time.DateTime
 
 import org.tresamigos.smv.util.Edd
 
-import org.apache.spark.sql.{DataFrame, SQLContext}
-import org.apache.spark.{SparkContext, SparkConf}
-
-import scala.collection.mutable
-import scala.util.{Try, Success, Failure}
-import java.util.List
-import collection.JavaConverters._
-
-import org.joda.time.DateTime
 
 
 /**
@@ -44,6 +45,13 @@ class SmvApp(private val cmdLineArgs: Seq[String],
 
   def stages      = smvConfig.stageNames
   val sparkConf   = new SparkConf().setAppName(smvConfig.appName)
+
+  val smvVersion  = {
+    val versionFile = Source.fromFile(f"${sys.env("SMV_HOME")}/.smv_version")
+    val nextLine = versionFile.getLines.next
+    versionFile.close
+  }
+
 
   /** Register Kryo Classes
    * Since none of the SMV classes will be put in an RDD, register them or not does not make

--- a/tools/_env.sh
+++ b/tools/_env.sh
@@ -126,6 +126,10 @@ function set_smv_spark_paths() {
   fi
 }
 
+function set_smv_home() {
+  local SMV_HOME="$(cd "`dirname "$0"/`/.."; pwd)"
+}
+
 # Remove trailing alphanum characters in dot-separated version text.
 function sanitize_version () {
   # match a digit, followed by a letter, "+" or "_," and anything up to a "."
@@ -198,6 +202,7 @@ USER_CMD=`basename $0`
 SMV_APP_CLASS="org.tresamigos.smv.SmvApp"
 split_smv_spark_args "$@"
 set_smv_spark_paths
+set_smv_home
 verify_spark_version
 check_help_option
 find_fat_jar


### PR DESCRIPTION
Resolves #1155. In order to keep the URL to the API doc up to date, I needed access to the current SMV version, so I added a property `smvVersion` that reads from `.smv_version` to `SmvApp`. I also fixed the organization of the imports in the files I touched. 