### PR TITLE
#1230 create column helper function smvTimestampToStr

### DIFF
--- a/docs/user/smv_python_progress.md
+++ b/docs/user/smv_python_progress.md
@@ -42,6 +42,7 @@
   * [x] `smvIsAllIn("value 1", "value 2")`
   * [x] `smvIsAnyIn("value 1", "value 2")`
   * [x] `smvStrToTimestamp("yyyyMMdd")`
+  * [x] `smvTimestampToStr("timezone:String","yyyy-MM-dd HH:mm:ssZ")`
   * [x] `smvMonth`
   * [x] `smvYear`
   * [x] `smvQuarter`

--- a/src/main/python/smv/helpers.py
+++ b/src/main/python/smv/helpers.py
@@ -1622,6 +1622,29 @@ class ColumnHelper(object):
         jc = self._jColumnHelper.smvStrToTimestamp(fmt)
         return Column(jc)
 
+    def smvTimestampToStr(self, timezone, fmt):
+        """Build a string from a timestamp and timezone
+
+            Args:
+                timezone (string or Column): the timezone follows the rules in https://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html#forID-java.lang.String-
+                                             It can be a string like "America/Los_Angeles" or "+1000". If it is null, use current system time zone.
+                fmt (string): the format is the same as the Java `Date` format
+
+            Example:
+                >>> df.select(col("ts").smvTimestampToStr("America/Los_Angeles","yyyy-MM-dd HH:mm:ss"))
+
+            Returns:
+                (Column): StringType. The converted String with given format
+        """
+        if is_string(timezone):
+            jtimezone = timezone
+        elif isinstance(timezone, Column):
+            jtimezone = timezone._jc
+        else:
+            raise RuntimeError("timezone parameter must be either an string or a Column")
+        jc = self._jColumnHelper.smvTimestampToStr(jtimezone, fmt)
+        return Column(jc)
+
     def smvDay70(self):
         """Convert a Timestamp to the number of days from 1970-01-01
 

--- a/src/main/python/smv/helpers.py
+++ b/src/main/python/smv/helpers.py
@@ -1626,8 +1626,9 @@ class ColumnHelper(object):
         """Build a string from a timestamp and timezone
 
             Args:
-                timezone (string or Column): the timezone follows the rules in https://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html#forID-java.lang.String-
-                                             It can be a string like "America/Los_Angeles" or "+1000". If it is null, use current system time zone.
+                timezone (string or Column): the timezone follows the rules in 
+                    https://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html#forID-java.lang.String-
+                    It can be a string like "America/Los_Angeles" or "+1000". If it is null, use current system time zone.
                 fmt (string): the format is the same as the Java `Date` format
 
             Example:

--- a/src/test/python/testColumnHelper.py
+++ b/src/test/python/testColumnHelper.py
@@ -184,3 +184,14 @@ class ColumnHelperTest(SmvBaseTest):
 
         self.should_be_same(res1, exp)
         self.should_be_same(res2, exp)
+
+    def test_smvTimestampToStr(self):
+        df = self.createDF("ts:Timestamp[yyyyMMdd'T'HHmmssZ];tz:String", "20180428T025800+1000,+0000;,America/Los_Angeles;20180428T025800+1000,Australia/Sydney")
+        r1 = df.select(col("ts").smvTimestampToStr("+10:00","yyyyMMdd:HHmmssz").alias("localDT"))
+        r2 = df.select(col("ts").smvTimestampToStr(col("tz"),"yyyy-MM-dd HH:mm:ssz").alias("localDT2"))
+
+        e1 = self.createDF("localDT: String", "20180428:025800+10:00;;20180428:025800+10:00")
+        e2 = self.createDF("localDT2: String", "2018-04-27 16:58:00+00:00;;2018-04-28 02:58:00+10:00")
+
+        self.should_be_same(e1, r1)
+        self.should_be_same(e2, r2)

--- a/src/test/scala/org/tresamigos/smv/ColumnHelperTest.scala
+++ b/src/test/scala/org/tresamigos/smv/ColumnHelperTest.scala
@@ -27,6 +27,22 @@ class ColumnHelperTest extends SmvTestUtil {
                           "null")
   }
 
+  test("test smvTimestampToStr") {
+    val ssc = sqlContext; import ssc.implicits._
+    val df  = dfFrom("ts:Timestamp[yyyyMMdd'T'HHmmssZ]; tz:String; v:String;",
+                      "20180428T025800+1000,UTC,a;" +
+                      "20180428T025800+1000,America/Los_Angeles,b;" +
+                      "20180428T025800+1000,-07:00,c;" +
+                      ",Australia/Sydney,d")
+    val res = df.select($"ts".smvTimestampToStr($"tz","yyyyMMdd'T'HHmmssZ"),
+                        $"ts".smvTimestampToStr("+1000","yyyy-MM-dd"))
+    assertSrddDataEqual(res,
+        "20180427T165800+0000,2018-04-28;" +
+        "20180427T095800-0700,2018-04-28;" +
+        "20180427T095800-0700,2018-04-28;" +
+        "null,null")
+  }
+
   test("test smvYear, smvMonth, smvQuarter, smvDayOfMonth, smvDayOfWeek") {
     val ssc = sqlContext; import ssc.implicits._
     val df  = dfFrom("k:Timestamp[yyyyMMdd]; v:String;", "20190101,a;,b")


### PR DESCRIPTION
Fix #1230 
Internally, I create Joda DateTime Object with a long number(timestamp) and given timezone(string), and then use Joda's DateTimeFormatter to return the string with given format.