### PR TITLE
add user_libraries prop to conf, decache py mods 

### DIFF
--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -51,8 +51,10 @@ class DataSetRepo(object):
             from the sys.modules dictionary to avoid getting cached modules from python when
             we contruct a new DSR.
         """
+        # The set of all user-defined code that needs to be decached
         # { 'stage1' } from our example
-        fqn_stubs_to_remove = { fqn.split('.')[0] for fqn in self.smvApp.stages() }
+        user_code_fqns = set(self.smvApp.stages()).union(self.smvApp.userLibs())
+        fqn_stubs_to_remove = {fqn.split('.')[0] for fqn in user_code_fqns}
 
         for loaded_mod_fqn in list(sys.modules.keys()):
             for stubbed_fqn in fqn_stubs_to_remove:

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -203,6 +203,10 @@ class SmvApp(object):
     def stages(self):
         """Stages is a function as they can be set dynamically on an SmvApp instance"""
         return self.j_smvPyClient.stages()
+    
+    def userLibs(self):
+        """Return dynamically set smv.user_libraries from conf"""
+        return self.j_smvPyClient.userLibs()
 
     def appId(self):
         return self.config().appId()

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -45,6 +45,8 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   val publishJDBC = smvConfig.cmdLine.publishJDBC()
 
   def stages      = smvConfig.stageNames
+  def userLibs    = smvConfig.userLibs
+
   val sparkConf   = new SparkConf().setAppName(smvConfig.appName)
 
   lazy val smvVersion  = {

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -204,11 +204,12 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
   private def homeConfProps = _loadProps(DEFAULT_SMV_HOME_CONF_FILE)
   private val cmdLineProps  = cmdLine.smvProps
   private val defaultProps = Map(
-    "smv.appName"     -> "Smv Application",
-    "smv.appId"       -> java.util.UUID.randomUUID.toString,
-    "smv.stages"      -> "",
-    "smv.config.keys" -> "",
-    "smv.class_dir"   -> "./target/classes"
+    "smv.appName"         -> "Smv Application",
+    "smv.appId"           -> java.util.UUID.randomUUID.toString,
+    "smv.stages"          -> "",
+    "smv.config.keys"     -> "",
+    "smv.class_dir"       -> "./target/classes",
+    "smv.user_libraries"  -> ""
   )
 
   // ---------- Dynamic Run Config Parameters key/values ----------
@@ -235,6 +236,9 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
 
   // --- stage names are a dynamic prop
   private[smv] def stageNames = { splitProp("smv.stages").toSeq }
+
+  // --- user libraries are dynamic as well
+  private[smv] def userLibs = { splitProp("smv.user_libraries").toSeq }
 
   val classDir = mergedProps("smv.class_dir")
 

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -261,6 +261,8 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   def outputDir: String = j_smvApp.smvConfig.outputDir
 
   def stages: Array[String] = j_smvApp.stages.toArray
+  
+  def userLibs: Array[String] = j_smvApp.userLibs.toArray
 
   def inferDS(name: String): SmvDataSet =
     j_smvApp.dsm.inferDS(name).head

--- a/src/test/python/testDynamicConfigAppDir.py
+++ b/src/test/python/testDynamicConfigAppDir.py
@@ -69,7 +69,7 @@ class RunModuleWithDynamicConfigAppDirTest(SmvBaseTest):
 
         # contents of project-a/conf/smv-app-conf.props:
         expected_props = { "smv.class_dir": "./target/classes", "smv.appName": "App A", \
-        "smv.config.keys": "", "smv.stages": "stage", "smv.appId": "PROJECT_A" }
+        "smv.config.keys": "", "smv.stages": "stage", "smv.appId": "PROJECT_A", "smv.user_libraries": "core" }
 
         #  tell the app to change dirs, which should cause the reload of conf for this project
         self.smvApp.setAppDir(self.proj_a_path)

--- a/src/test/python/testDynamicConfigAppDir/project-a/conf/smv-app-conf.props
+++ b/src/test/python/testDynamicConfigAppDir/project-a/conf/smv-app-conf.props
@@ -6,3 +6,6 @@ smv.stages = stage
 
 # static appId for testing
 smv.appId = PROJECT_A
+
+# dummy user_libraries key
+smv.user_libraries = core


### PR DESCRIPTION
Fixes #1163
- Adds a potential prop to Smv config for 'user_libraries'
- Uses that prop with existing 'decache python module' strategy in `DataSetRepo` so that UDL's are reloaded.