### PR TITLE
Enable creating empty projects with 'smv-init'

### DIFF
--- a/tools/smv-init
+++ b/tools/smv-init
@@ -10,56 +10,82 @@ TEMPLATE_DATA_DIR="$TEMPLATE_DIR/data"
 PROJ_TYPE="simple"
 OVERRIDE=0
 
+
 while [[ $# -gt 1 ]]
 do
 FLAG=$1
 
   case $FLAG in
     -q)
-    QUITE_MODE=1
-    shift
-    ;;
+        QUITE_MODE=1
+        shift
+        ;;
+    -b|-blank)
+        PROJ_TYPE="blank"
+        shift
+        ;;
     -s|-simple)
-    PROJ_TYPE="simple"
-    shift
-    ;;
+        PROJ_TYPE="simple"
+        shift
+        ;;
     -e|-enterprise)
-    PROJ_TYPE="enterprise"
-    shift
-    ;;
+        PROJ_TYPE="enterprise"
+        shift
+        ;;
     -t|-test)
-    PROJ_TYPE="test"
-    shift
-    ;;
+        PROJ_TYPE="test"
+        shift
+        ;;
     -b|-big)
-    PROJ_TYPE="big"
-    shift
-    ;;
+        PROJ_TYPE="big"
+        shift
+        ;;
+    -dd|-dataDir)
+        PROJ_DATA_DIR="$2"
+        shift
+        shift
+        ;;
+    -n|-name)
+        PROJ_NAME="$2"
+        shift
+        shift
+        ;;
     -o)
     OVERRIDE=1
-    shift
-    ;;
+        shift
+        ;;
     *)
-    ;;
+        ;;
   esac
 done
+
+echo 'after parsing args'
+echo num args: $#
 
 TEMPLATE_DIR+="/$PROJ_TYPE"
 
 if [ $# -ne 1 ]; then
     echo "ERROR: Invalid number of arguments"
-    echo "USAGE: $0 [-q][-o] [-s|-e|-t] project_name"
+    echo "USAGE: $0 [-q][-o] [-s|-e|-t|-b] [-dd] [-n]  project_path"
     echo "project types:"
     echo "  -s: simple (default)"
     echo "  -e: enterprise"
     echo "  -t: test (for developers only)"
+    echo "  -b: blank/empty project"
+    echo "  -dd: data directory"
+    echo "  -n: project name"
+    echo # TODO
     echo "example:"
-    echo "  \$ $0 MyProject"
+    echo "    simple:     \$ ./tools/smv-init /project/path"
+    echo "    blank:      \$ ./tools/smv-init -b -n projec_name -dd /data/dir /project/path"
+    echo "    enterprise: \$ ./tools/smv-init -e /project/path"
     exit 1
 fi
 
 PROJ_DIR="$1"
 PROJ_CLASS=""
+STAGE_NAME="`echo $PROJ_NAME | tr '[:upper:]' '[:lower:]'`"
+PROJ_DATA_DIR=${PROJ_DATA_DIR:="${PROJ_DIR}/data"} # default data dir is /data in project dir
 
 # proj class hardcoded for smv integration tests
 if [ "$PROJ_TYPE" = "test" ]; then
@@ -103,17 +129,20 @@ function create_proj_dir()
 
 function copy_with_inject()
 {
+    ESCAPED_FULL_PATH=$(echo ${PROJ_DIR_FULL_PATH} | sed -e 's/[\/&]/\\&/g')
+    ESCAPED_DATA_DIR=$(echo ${PROJ_DATA_DIR} | sed -e 's/[\/&]/\\&/g')
+
     SRC="$1"
     DST="$2"
-    echo "-- copying `basename "$DST"`"
-
-    ESCAPED_FULL_PATH=$(echo ${PROJ_DIR_FULL_PATH}|sed -e 's/[\/&]/\\&/g')
 
     mkdir -p "$(dirname "$DST")"
     sed -e "s/_GROUP_ID_/$PROJ_GROUP_ID/" \
         -e "s/_ARTIFACT_ID_/$PROJ_ARTIFACT_ID/" \
         -e "s/_PROJ_CLASS_/$PROJ_CLASS/g" \
         -e "s/_PROJ_DIR_FULL_PATH_/${ESCAPED_FULL_PATH}/g" \
+        -e "s/_PROJ_NAME_/$PROJ_NAME/g" \
+        -e "s/_STAGE_NAME_/$STAGE_NAME/g" \
+        -e "s/_PROJ_DATA_DIR_/$ESCAPED_DATA_DIR/g" \
         < "$SRC" > "$DST"
 }
 
@@ -138,18 +167,19 @@ function copy_conf_files()
       done
     fi
 
-
     # .gitignore was postfixed with .template so it does not affect SMV's git repo
     mv "$PROJ_DIR/.gitignore.template" "$PROJ_DIR/.gitignore"
 }
 
 function copy_data_files()
 {
-    data_dir=$1
+    if [ "$PROJ_TYPE" != "empty" ]; then
+        data_dir=$1
 
-    echo "-- copying data files"
+        echo "-- copying data files"
 
-    cp -R "$data_dir" "$PROJ_DIR"
+        cp -R "$data_dir" "$PROJ_DIR"
+    fi
 }
 
 function copy_src_dir()
@@ -171,26 +201,30 @@ function copy_src_files()
 
     PROJ_CLASS_PATH="`echo $PROJ_CLASS | sed -e 's/\./\//g'`"
 
-    if [ "$PROJ_TYPE" = "simple" ] || [ "$PROJ_TYPE" = "enterprise" ] || [ "$PROJ_TYPE" = "big" ]; then
-      for subdir in main/python; do
+    if [ "$PROJ_TYPE" = "test" ]; then
+      for subdir in main/scala main/python; do
           copy_src_dir ${subdir} ${PROJ_CLASS_PATH}
       done
     else
-      for subdir in main/scala main/python; do
-          copy_src_dir ${subdir} ${PROJ_CLASS_PATH}
+      STAGE_NAME_PATH="`echo $STAGE_NAME | sed -e 's/\./\//g'`"
+
+      for subdir in main/python; do
+          copy_src_dir ${subdir} ${STAGE_NAME_PATH}
       done
     fi
 }
 
 function create_python_packages()
 {
+    echo '-- creating python packages'
     for dir in $(ls -d ${PROJ_DIR_FULL_PATH}/src/main/python/*/); do
         find ${dir} -type d -print0 | xargs -0 -I\{\} touch \{\}/__init__.py
     done
 }
 
 # --- MAIN ---
-# only test proj has PROJ_CLASS
+
+#  only test proj has PROJ_CLASS
 if [ "$PROJ_TYPE" = "test" ] ; then
   extract_group_artifact_ids
 fi

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -54,13 +54,14 @@ FLAG=$1
     OVERRIDE=1
         shift
         ;;
+    -gi|-gitinit)
+        DO_GIT_INIT=1
+        shift
+        ;;
     *)
         ;;
   esac
 done
-
-echo 'after parsing args'
-echo num args: $#
 
 TEMPLATE_DIR+="/$PROJ_TYPE"
 
@@ -74,7 +75,8 @@ if [ $# -ne 1 ]; then
     echo "  -b: blank/empty project"
     echo "  -dd: data directory"
     echo "  -n: project name"
-    echo # TODO
+    echo "  -gi: initializes git repo in project directory"
+    echo
     echo "example:"
     echo "    simple:     \$ ./tools/smv-init /project/path"
     echo "    blank:      \$ ./tools/smv-init -b -n projec_name -dd /data/dir /project/path"
@@ -173,7 +175,7 @@ function copy_conf_files()
 
 function copy_data_files()
 {
-    if [ "$PROJ_TYPE" != "empty" ]; then
+    if [ "$PROJ_TYPE" != "blank" ]; then
         data_dir=$1
 
         echo "-- copying data files"
@@ -222,6 +224,29 @@ function create_python_packages()
     done
 }
 
+function create_notebooks_folder()
+{
+  echo "--  creating notebooks folder"
+
+  cd ${PROJ_DIR_FULL_PATH} && mkdir notebooks && touch notebooks/_jupyter_notebooks_
+}
+
+function create_library_folder()
+{
+    echo "-- creating library folder"
+
+    cd ${PROJ_DIR_FULL_PATH} && mkdir library
+}
+
+function create_git_structure()
+{
+    if [ "$DO_GIT_INIT" = 1 ]; then
+        echo "-- initializing git repository"
+
+        cd ${PROJ_DIR_FULL_PATH} && git init && git add . && git commit -m "init commit"
+    fi
+}
+
 # --- MAIN ---
 
 #  only test proj has PROJ_CLASS
@@ -245,3 +270,7 @@ if [ "$PROJ_TYPE" = "big" ] ; then
   $TEMPLATE_DIR/dupMod.sh $PROJ_DIR/src/main/python/stage1/employment.py $PROJ_DIR/src/main/python/stage1/ 1000
   rm $PROJ_DIR/src/main/python/stage1/employment.py
 fi
+
+create_notebooks_folder
+create_library_folder
+create_git_structure

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -21,7 +21,7 @@ FLAG=$1
         QUITE_MODE=1
         shift
         ;;
-    -b|-blank)
+    -b|--blank)
         PROJ_TYPE="blank"
         shift
         ;;
@@ -41,12 +41,12 @@ FLAG=$1
         PROJ_TYPE="big"
         shift
         ;;
-    -dd|-dataDir)
+    -d|--dataDir)
         PROJ_DATA_DIR="$2"
         shift
         shift
         ;;
-    -n|-name)
+    -n|--name)
         PROJ_NAME="$2"
         shift
         shift
@@ -55,7 +55,7 @@ FLAG=$1
     OVERRIDE=1
         shift
         ;;
-    -g|-git)
+    -g|--git)
         DO_GIT_INIT=1
         shift
         ;;
@@ -74,9 +74,9 @@ if [ $# -ne 1 ]; then
     echo "  -e: enterprise"
     echo "  -t: test (for developers only)"
     echo "  -b: blank/empty project"
-    echo "  -dd: data directory"
+    echo "  -d: data directory"
     echo "  -n: project name"
-    echo "  -gi: initializes git repo in project directory"
+    echo "  -g: initializes git repo in project directory"
     echo
     echo "example:"
     echo "    simple:     \$ ./tools/smv-init /project/path"

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -9,6 +9,7 @@ TEMPLATE_DATA_DIR="$TEMPLATE_DIR/data"
 #  - test
 PROJ_TYPE="simple"
 OVERRIDE=0
+DO_GIT_INIT=0
 
 
 while [[ $# -gt 1 ]]

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -224,13 +224,6 @@ function create_python_packages()
     done
 }
 
-function create_notebooks_folder()
-{
-  echo "--  creating notebooks folder"
-
-  cd ${PROJ_DIR_FULL_PATH} && mkdir notebooks && touch notebooks/_jupyter_notebooks_
-}
-
 function create_library_folder()
 {
     echo "-- creating library folder"
@@ -256,13 +249,7 @@ fi
 
 create_proj_dir
 copy_conf_files
-
-if [ "$PROJ_TYPE" = "test" ]; then
-  copy_data_files "$TEMPLATE_DIR/data"
-else
-  copy_data_files $TEMPLATE_DATA_DIR
-fi
-
+copy_data_files $TEMPLATE_DATA_DIR
 copy_src_files
 create_python_packages
 
@@ -271,6 +258,5 @@ if [ "$PROJ_TYPE" = "big" ] ; then
   rm $PROJ_DIR/src/main/python/stage1/employment.py
 fi
 
-create_notebooks_folder
 create_library_folder
 create_git_structure

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -55,7 +55,7 @@ FLAG=$1
     OVERRIDE=1
         shift
         ;;
-    -gi|-gitinit)
+    -g|-git)
         DO_GIT_INIT=1
         shift
         ;;

--- a/tools/templates/blank/.gitignore.template
+++ b/tools/templates/blank/.gitignore.template
@@ -1,0 +1,40 @@
+conf/smv-user-conf.props
+
+data/output
+data/history
+
+.idea
+smv.iml
+/bin/
+/.settings/
+/.classpath
+/.project
+/.cache
+**/.c9*
+derby.log
+metastore_db/
+.DS_Store
+.ensime*
+
+*.class
+*.log
+*.pyc
+*.pyo
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+# IPython Notebook
+.ipynb_checkpoints

--- a/tools/templates/blank/README.md
+++ b/tools/templates/blank/README.md
@@ -1,0 +1,12 @@
+
+Full details on how to build/run/use this application can be found in the [Getting Started section of the SMV User Guide](https://github.com/TresAmigosSD/SMV/blob/master/docs/user/getting_started.md)
+
+# Run App in batch
+```shell
+$ smv-pyrun --run-app
+```
+
+# Run App in Spark Shell
+```shell
+$ smv-pyshell
+```

--- a/tools/templates/blank/conf/smv-app-conf.props
+++ b/tools/templates/blank/conf/smv-app-conf.props
@@ -1,0 +1,5 @@
+# application name
+smv.appName = _PROJ_NAME_
+
+# stage definitions
+smv.stages = _STAGE_NAME_

--- a/tools/templates/blank/conf/smv-user-conf.props
+++ b/tools/templates/blank/conf/smv-user-conf.props
@@ -1,0 +1,2 @@
+# data dir
+smv.dataDir = file://_PROJ_DATA_DIR_

--- a/tools/templates/blank/log4j.properties
+++ b/tools/templates/blank/log4j.properties
@@ -1,0 +1,11 @@
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO

--- a/tools/templates/blank/notebooks/Untitled.ipynb
+++ b/tools/templates/blank/notebooks/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Fixes: #1250 

### Summary
- Allows user to create an empty project using `smv-init` script
- Interface to create projects has not been changed. Creating a simple, test, enterprise projects using `smv-init` remains the same
- New options args added to `smv-init` shell script:
  - `-b | -blank`: creates an empty/blank project
  - `-n | -name`: sets `smv.appName` in `smv-app-conf.props` with the value of the following arg (empty projects only)
  - `-dd | -dataDir`: sets `smv.dataDir` in `smv-user-conf.props` (optional, empty projects only)

E.g.:
- creating a `simple` project (with some sample modules)
```bash
$ ./tools/smv-init /project/path
```
- creating an `empty/blank` project
```bash
$ ./tools/smv-init -b -n <ProjectName> -dd </project/data/dir> </project/path>
```

![init](https://user-images.githubusercontent.com/5383318/40691060-f95e7784-635e-11e8-9267-4851cab73fa3.gif)
