### PR TITLE
Use Libs in Hash

### DIFF
--- a/docs/dev/Python/reload_python_code.md
+++ b/docs/dev/Python/reload_python_code.md
@@ -8,13 +8,15 @@ There are currently several issues (#641, #642, #646, etc.) which result from co
 
 Within a transaction, we want every module needed within the transaction to be loaded from the most recent source _once_ (#646 has illustrates a problem that can arise from loading a module twice in a transaction).
 
+## Initial Approach
+
+We initially tried to approximate this behavior by reloading a module using the builtin `reload` function every time we load one of its member `SmvDataSets` (putting it briefly). Complications have arisen when we want to assure that the module is loaded only once, when we want to make sure that inheritance dependencies are also reloaded, etc.
+
+Using the built-in `reload` also causes some potentially unexpected behaviour for users as reloaded modules are different objects (would fail `instanceof` checks) and sub-modules are not reloaded recursively.
+
 ## Current Approach
 
-We currently approximate this behavior by reloading a module using the builtin `reload` function every time we load one of its member `SmvDataSets` (putting it briefly). Complications have arisen when we want to assure that the module is loaded only once, when we want to make sure that inheritance dependencies are also reloaded, etc.
-
-## Alternative Approach
-
- Essentially, during each transaction client code should be loaded as though it was run in a fresh interpreter. We should be able to accomplish this by removing all client modules from `sys.modules` at the beginning of each transaction (a similar strategy is outlined [here](https://www.safaribooksonline.com/library/view/python-cookbook/0596001673/ch14s02.html)). We may need to suppress creation of `.pyc` files (which would also solve #612) if Python falls back on these instead of recompiling. We also will need to investigate if this has unintended consequences for the `linecache` - we may need to invalidate the entire `linecache` at the beginning of the transaction instead of on a case by case basis. However, the objective of this approach is to force the interpreter to forget about client modules it imported before the current transaction, compile them the first time they are imported during the current transaction, and import them without compilation every subsequent time they are imported within the current transaction.
+ Essentially, during each transaction client code should be loaded as though it was run in a fresh interpreter. We accomplish this by removing all client modules from `sys.modules` at the beginning of each transaction (a similar strategy is outlined [here](https://www.safaribooksonline.com/library/view/python-cookbook/0596001673/ch14s02.html)). We may need to suppress creation of `.pyc` files (which would also solve #612) if Python falls back on these instead of recompiling. We also will need to investigate if this has unintended consequences for the `linecache` - we may need to invalidate the entire `linecache` at the beginning of the transaction instead of on a case by case basis. However, the objective of this approach is to force the interpreter to forget about client modules it imported before the current transaction, compile them the first time they are imported during the current transaction, and import them without compilation every subsequent time they are imported within the current transaction.
 
 ### Sys Module Popping strategies
 We investigated a few different strategies for popping modules from `sys.modules` for the purposes described above:

--- a/docs/dev/Python/reload_python_code.md
+++ b/docs/dev/Python/reload_python_code.md
@@ -1,23 +1,31 @@
-# Issues Reloading Python Code
+# Python Module Reloading
+
+## Issues Reloading Python Code
 
 There are currently several issues (#641, #642, #646, etc.) which result from complications in managing the reloading of client Python code within a transaction. We could solve each of them individually, introducing additional nuances and complications to the process of loading modules, but it is preferable to come to a more general solution both for simplicity and to prevent similar future problems.
 
-# Desired Behavior
+## Desired Behavior
 
 Within a transaction, we want every module needed within the transaction to be loaded from the most recent source _once_ (#646 has illustrates a problem that can arise from loading a module twice in a transaction).
 
-# Current Approach
+## Current Approach
 
 We currently approximate this behavior by reloading a module using the builtin `reload` function every time we load one of its member `SmvDataSets` (putting it briefly). Complications have arisen when we want to assure that the module is loaded only once, when we want to make sure that inheritance dependencies are also reloaded, etc.
 
-# Alternative Approach
+## Alternative Approach
 
  Essentially, during each transaction client code should be loaded as though it was run in a fresh interpreter. We should be able to accomplish this by removing all client modules from `sys.modules` at the beginning of each transaction (a similar strategy is outlined [here](https://www.safaribooksonline.com/library/view/python-cookbook/0596001673/ch14s02.html)). We may need to suppress creation of `.pyc` files (which would also solve #612) if Python falls back on these instead of recompiling. We also will need to investigate if this has unintended consequences for the `linecache` - we may need to invalidate the entire `linecache` at the beginning of the transaction instead of on a case by case basis. However, the objective of this approach is to force the interpreter to forget about client modules it imported before the current transaction, compile them the first time they are imported during the current transaction, and import them without compilation every subsequent time they are imported within the current transaction.
 
- # Update: Behavior Changes
+### Sys Module Popping strategies
+We investigated a few different strategies for popping modules from `sys.modules` for the purposes described above:
 
- Users should not expect significant changes to the behavior of SMV outside of fixes for the described bugs. However, since the implementation we have noticed changes to certain internal assumptions about reloading modules.
+1. **Name-based:** We assemble a set of module names that comprise the application code based off of the applications stages and libraries as enumerated in the application configuration props. Then, we iterate through `sys.modules` and pop each module that starts with a stage/library name followed by a `.` character to de-cache the modules at the python level. For example, for an application with a stage named `foo` and module in `sys.modules` named `foo.bar`, `foo.bar.baz` and `foozeball`, we will pop `foo.bar` and `foo.bar.baz` but not `foozeball`. This is the solution we use currently.
+2. **Path-based:** We investigated a solution where the `__file__` path of each module was used to try to determine if the module was part of application code (ie: the module is from `<app-directory>/src/main/python` or `<app-directory>/library`). This approach won't work because at the start of each transaction, we decache the modules from the last transaction that may collide. Since app directory is _dynamic_ this approach doesn't gurantee that potentially colliding modules will be decached. For example, the same project clones in two different locations and run one after the other in the same session will break this approach.
+3. **Inpsection-based:** We investigated a solution similar to the first solution for stages, but aimed at removing the necessity to enumerate libraries in the application configuration props by inspecting each application module (ie `foo.bar`) for its members and reloading them if they were a class or module. This approach added significant performance drag and greatly increased the complexity of the reloading code, so we rejected it in favor of approach 1 of this list.
 
- ## Module identity and reference counting
+> **Update: Behavior Changes -**
+> Users should not expect significant changes to the behavior of SMV outside of fixes for the described bugs. However, since the implementation we have noticed changes to certain internal assumptions about reloading modules.
+
+### Module identity and reference counting
 
  When reloading a module using Python's built-in `reload`, no new module is created - the resulting module has different attributes, but the same identity as the original. However, after deleting a module from `sys.modules` and importing it again, the resulting module is a new object with a new identity. This is makes sense - it is the behavior we originally expected from reload. However, we did not anticipate that deleting a module from `sys.modules` may reduce the module's reference count to zero, causing that module to get cleaned up. We can ensure that this will never affect users by 1. never giving users direct access to modules and 2. never reusing modules from a transaction after a second transaction has been started; however, this led to a strange bug in our Python unit test suite. The scenario was that `testDataFrameHelper` contained a module `T` that was used in several tests, including `test_smvExportCsv`, where it was run using `SmvApp.runModule`. Immediately after `runModule`, all of the module's global names resolved to `None`. This was difficult to replicate outside of the test suite. We eventually discovered that maintaining a reference to the old `testDataFrameHelper` module prevented this problem, and from there worked out that when we removed the `sys.modules's` reference to `testDataFrameHelper` we were removing the last one, causing `testDataFrameHelper` to get cleaned up in the process. It appears that when a module is cleaned up, at least some of the mappings in its globals dict are overwritten with `None`. Functions defined inside the module are still, however, using that same globals dict to look up names dynamically, and as a result getting `None` for names which a shortly ago were defined.

--- a/docs/user/app_config.md
+++ b/docs/user/app_config.md
@@ -119,7 +119,7 @@ Note that for sequence/list type parameters (e.g. smv.stages), a "," or ":" can 
 <td>smv.user_libraries</td>
 <td>empty</td>
 <td>Optional</td>
-<td>A list of external (not SMV DataSet subclass instances) modules, functions and/or objects that should be reloaded with the project</td>
+<td>A list of external python modules, functions and/or objects that should be reloaded with the project</td>
 </tr>
 
 <tr>

--- a/docs/user/app_config.md
+++ b/docs/user/app_config.md
@@ -116,6 +116,13 @@ Note that for sequence/list type parameters (e.g. smv.stages), a "," or ":" can 
 </tr>
 
 <tr>
+<td>smv.user_libraries</td>
+<td>empty</td>
+<td>Optional</td>
+<td>A list of external (not SMV DataSet subclass instances) modules, functions and/or objects that should be reloaded with the project</td>
+</tr>
+
+<tr>
 <th colspan="4">Data Directories Parameters</th>
 </tr>
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -40,7 +40,7 @@ This means cached data will be invalidated if the external code is changed, etc.
 
 There are two steps to setting this up for your project:
 
-1. Add the library to your app conf via either of the files under `conf/` or the command line under the `smv.user_libraries` property.
+1. Add the `smv.user_libraries` prop to your [app configuration](./app_config.md).
 
 2. Import the library in all files that depend on it (like `import udl as lib`) and then in the class defs of DataSets that depend on it, implement the `requiresLib()` method and make it return an array of the libraries that that DataSet depends on (for the first example, `requiresLib()` would return `[lib]`).
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -36,9 +36,22 @@ Any of the classes listed above can implement a `requiresLib()` function to defi
 
 This means cached data will be invalidated if the external code is changed, etc.
 
+> **Limitations:** For python modules and packages, the `requiresLib()` method is limited to registering changes on the main file of the package (for module `foo`, that's `foo.py`, for package `bar`, that's `bar/__init__.py`). This means that if a module or package imports other modules, the imported module's changes will not impact DataSet hashes.
+
+There are two steps to setting this up for your project:
+
+1. Add the library to your app conf via either of the files under `conf/` or the command line under the `smv.user_libraries` property.
+
+2. Import the library in all files that depend on it (like `import udl as lib`) and then in the class defs of DataSets that depend on it, implement the `requiresLib()` method and make it return an array of the libraries that that DataSet depends on (for the first example, `requiresLib()` would return `[lib]`).
+
 **Python**
 
 ```py
+# in smv-app-conf.props:
+smv.stages = stage
+smv.user_libraries = lib, pandas
+
+# in src/main/python/stage/someFile.py:
 import some_library as lib
 import pandas
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -20,15 +20,42 @@ directly, instead, they will use all the detailed types of `SmvDataSet`.
 
 In this document we will cover the following basic `SmvDataSet`s,
 
- | Scala | Python
---- | --- | ---
-**Input** | `SmvCsvFile` | `SmvCsvFile`
-          | `SmvMultiCsvFiles` | `SmvMultiCsvFiles`
-          | `SmvCsvStringData` | `SmvCsvStringData`
-          | `SmvHiveTable` | `SmvHiveTable`
-**Intermediate** | `SmvModule` | `SmvModule`
-**Output** (mix in) | `SmvOutput` | `SmvOutput`
+|                     | Scala              | Python             |
+|---------------------|--------------------|--------------------|
+| **Input**           | `SmvCsvFile`       | `SmvCsvFile`       |
+|                     | `SmvMultiCsvFiles` | `SmvMultiCsvFiles` |
+|                     | `SmvCsvStringData` | `SmvCsvStringData` |
+|                     | `SmvHiveTable`     | `SmvHiveTable`     |
+| **Intermediate**    | `SmvModule`        | `SmvModule`        |
+| **Output (mix in)** | `SmvOutput`        | `SmvOutput`        |
+|                     |                    |                    |
 
+### External Code Dependency (python only)
+
+Any of the classes listed above can implement a `requiresLib()` function to define code that isn't SMV DataSets (like an external or user-defined library) that should be considered like it is part of the source of the DataSet itself.
+
+This means cached data will be invalidated if the external code is changed, etc.
+
+**Python**
+
+```py
+import some_library as lib
+import pandas
+
+class MyModule(smv.SmvModule):
+    """mod description"""
+    # define dependency on other SmvDataset(s)
+    def requiresDS(self):
+        return [Mod1, Mod2]
+
+    # define dependency on arbitary external code
+    # ie: libraries defined in your project or from pip
+    def requiresLib(self):
+        return [lib, pandas]
+
+    def run(self, i):
+        ...
+```
 
 ## Input SmvDataSet
 

--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -145,13 +145,14 @@ class SmvDataSet(ABC):
         """
     
     def requiresLib(self):
-        """User-specified list of user-defined (not external) library dependencies
+        """User-specified list of 'library' dependencies. These are code, other than
+            the DataSet's run method that impact its output or behaviour.
 
             Override this method to assist in re-running this module based on changes
-            in other python files.
+            in other python objects (functions, classes, packages).
 
             Returns:
-                (list(Module)): a list of library dependencies
+                (list(module)): a list of library dependencies
         """
         return []
 

--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -143,6 +143,7 @@ class SmvDataSet(ABC):
 
             The given keys and their values will influence the dataset hash
         """
+        return []
     
     def requiresLib(self):
         """User-specified list of 'library' dependencies. These are code, other than
@@ -150,6 +151,12 @@ class SmvDataSet(ABC):
 
             Override this method to assist in re-running this module based on changes
             in other python objects (functions, classes, packages).
+
+            Limitations: For python modules and packages, the 'requiresLib()' method is
+            limited to registering changes on the main file of the package (for module
+            'foo', that's 'foo.py', for package 'bar', that's 'bar/__init__.py'). This
+            means that if a module or package imports other modules, the imported
+            module's changes will not impact DataSet hashes.
 
             Returns:
                 (list(module)): a list of library dependencies

--- a/src/test/python/testModuleHash.py
+++ b/src/test/python/testModuleHash.py
@@ -21,7 +21,7 @@ from smv.datasetrepo import DataSetRepo
 class ModuleHashTest(SmvBaseTest):
     @classmethod
     def smvAppInitArgs(cls):
-        return ["--smv-props", "smv.stages=stage", "smv.user_libraries=udl"]
+        return ["--smv-props", "smv.stages=stage", "smv.user_libraries=udl:same"]
 
     @classmethod
     def before_dir(cls):
@@ -38,10 +38,6 @@ class ModuleHashTest(SmvBaseTest):
             self.orig_path = os.getcwd()
             self.target_path = target_path
             self.fqn = fqn
-        
-        def lib_path(self):
-            # use a realistic library dir, which we'll also add to py path
-            return self.path + "/library"
 
         def __enter__(self):
             self.smvApp.setAppDir(self.target_path)
@@ -79,9 +75,21 @@ class ModuleHashTest(SmvBaseTest):
         """hash will change if we change module's requiresDS"""
         self.assert_hash_should_change("stage.modules.Dependent")
     
+    def test_unchanged_lib_same_hash(self):
+        """verify that the same library source will produce the same hash"""
+        self.assert_hash_should_not_change("stage.modules.SameLibrary")
+    
     def test_change_required_lib_should_change_hash(self):
         """hash will change if we modify the source code of a depended-on library"""
-        self.assert_hash_should_change("stage.modules.RequiresALibrary")
+        self.assert_hash_should_change("stage.modules.DifferentLibrary")
+    
+    def test_unchanged_func_same_hash(self):
+        """verify hash is the same if a function in requiresLib is"""
+        self.assert_hash_should_not_change("stage.modules.SameFunc")
+    
+    def test_change_func_should_change_hash(self):
+        """verify that changing the source of a required function changes hash"""
+        self.assert_hash_should_change("stage.modules.DifferentFunc")
 
     def test_change_baseclass_should_change_hash(self):
         """hash will change if we change code for class that module inherits from"""

--- a/src/test/python/testModuleHash.py
+++ b/src/test/python/testModuleHash.py
@@ -41,14 +41,10 @@ class ModuleHashTest(SmvBaseTest):
 
         def __enter__(self):
             self.smvApp.setAppDir(self.target_path)
-            sys.path.insert(1, self.target_path)
-            sys.path.insert(1, self.lib_path())
             return self.dsr.loadDataSet(self.fqn)
 
         def __exit__(self, type, value, traceback):
             self.smvApp.setAppDir(self.orig_path)
-            sys.path.remove(self.target_path)
-            sys.path.remove(self.lib_path())
 
     def compare_resource_hash(self, fqn, assertion):
         with self.Resource(self.smvApp,self.before_dir(),fqn) as ds:

--- a/src/test/python/testModuleHash/after/library/same.py
+++ b/src/test/python/testModuleHash/after/library/same.py
@@ -1,0 +1,2 @@
+def UnchangedFunction():
+    return "the same thing every time"

--- a/src/test/python/testModuleHash/after/library/udl.py
+++ b/src/test/python/testModuleHash/after/library/udl.py
@@ -1,0 +1,2 @@
+def getNumber(self):
+    return 10

--- a/src/test/python/testModuleHash/after/src/main/python/stage/modules.py
+++ b/src/test/python/testModuleHash/after/src/main/python/stage/modules.py
@@ -11,27 +11,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import udl as lib
+import same as unchanged
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
+
+def sameFunc():
+    """a function which is the same in before/after"""
+    return "I'm the same!"
+
+def differentFunc():
+    """a function that has different source in before/after"""
+    return "I'm in after!"
 
 class ChangeCode(SmvModule):
     def requiresDS(self):
         return []
     def run(self, i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,2")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,3")
 
 class AddComment(SmvModule):
+    # I ADDED A COMMENT, POP!
     def requiresDS(self):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,5")
 
-class DependencyA(SmvModule):
+class DependencyB(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,6")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,215")
 
-class Dependent(DependencyA):
+class Dependent(DependencyB):
     def requiresDS(self):
         return []
     def run(self,i):
@@ -41,9 +51,9 @@ class Upstream(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
 
-class RequiresALibrary(SmvModule):
+class DifferentLibrary(SmvModule):
     def requiresDS(self):
         return []
     def requiresLib(self):
@@ -51,6 +61,34 @@ class RequiresALibrary(SmvModule):
     def run(self, i):
         number = lib.getNumber()
         return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
+
+class SameLibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [unchanged]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', unchanged.UnchangedFunction())
+
+class SameFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [sameFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', sameFunc())
+
+
+class DifferentFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [differentFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', differentFunc())
 
 class Downstream(SmvModule):
     def requiresDS(self):
@@ -62,7 +100,7 @@ class Parent(SmvModule):
     def requiresDS(self):
         return[Upstream]
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,30")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,31")
 
 class HiveTableWithVersion(SmvHiveTable):
     def requiresDS(self):
@@ -70,7 +108,7 @@ class HiveTableWithVersion(SmvHiveTable):
     def tableName(self):
         return "HiveTableWithVersion"
     def version(self):
-        return "1.0"
+        return "1.1"
 
 class CsvFileWithRun(SmvCsvFile):
     def requiresDS(self):
@@ -78,7 +116,7 @@ class CsvFileWithRun(SmvCsvFile):
     def path(self):
         return "foo"
     def run(self, df):
-        return df
+        return df.select("bar")
 
 class Child(Parent):
     pass

--- a/src/test/python/testModuleHash/after/stage/modules.py
+++ b/src/test/python/testModuleHash/after/stage/modules.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import udl as lib
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
 
 class ChangeCode(SmvModule):
@@ -43,6 +43,15 @@ class Upstream(SmvModule):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
+
+class RequiresALibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [lib]
+    def run(self, i):
+        number = lib.getNumber()
+        return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
 
 class Downstream(SmvModule):
     def requiresDS(self):

--- a/src/test/python/testModuleHash/before/library/same.py
+++ b/src/test/python/testModuleHash/before/library/same.py
@@ -1,0 +1,2 @@
+def UnchangedFunction():
+    return "the same thing every time"

--- a/src/test/python/testModuleHash/before/library/udl.py
+++ b/src/test/python/testModuleHash/before/library/udl.py
@@ -1,0 +1,2 @@
+def getNumber(self):
+    return 1

--- a/src/test/python/testModuleHash/before/src/main/python/stage/modules.py
+++ b/src/test/python/testModuleHash/before/src/main/python/stage/modules.py
@@ -11,28 +11,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import udl as lib
+import same as unchanged
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
+
+def sameFunc():
+    """a function which is the same in before/after"""
+    return "I'm the same!"
+
+def differentFunc():
+    """a function that has different source in before/after"""
+    return "I'm in before!"
 
 class ChangeCode(SmvModule):
     def requiresDS(self):
         return []
     def run(self, i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,3")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,2")
 
 class AddComment(SmvModule):
-    # I ADDED A COMMENT, POP!
     def requiresDS(self):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,5")
 
-class DependencyB(SmvModule):
+class DependencyA(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,215")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,6")
 
-class Dependent(DependencyB):
+class Dependent(DependencyA):
     def requiresDS(self):
         return []
     def run(self,i):
@@ -42,9 +50,9 @@ class Upstream(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
 
-class RequiresALibrary(SmvModule):
+class DifferentLibrary(SmvModule):
     def requiresDS(self):
         return []
     def requiresLib(self):
@@ -52,6 +60,34 @@ class RequiresALibrary(SmvModule):
     def run(self, i):
         number = lib.getNumber()
         return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
+
+
+class SameLibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [unchanged]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', unchanged.UnchangedFunction())
+
+class SameFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [sameFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', sameFunc())
+
+class DifferentFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [differentFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', differentFunc())
 
 class Downstream(SmvModule):
     def requiresDS(self):
@@ -63,7 +99,7 @@ class Parent(SmvModule):
     def requiresDS(self):
         return[Upstream]
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,31")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,30")
 
 class HiveTableWithVersion(SmvHiveTable):
     def requiresDS(self):
@@ -71,7 +107,7 @@ class HiveTableWithVersion(SmvHiveTable):
     def tableName(self):
         return "HiveTableWithVersion"
     def version(self):
-        return "1.1"
+        return "1.0"
 
 class CsvFileWithRun(SmvCsvFile):
     def requiresDS(self):
@@ -79,7 +115,7 @@ class CsvFileWithRun(SmvCsvFile):
     def path(self):
         return "foo"
     def run(self, df):
-        return df.select("bar")
+        return df
 
 class Child(Parent):
     pass

--- a/src/test/python/testModuleHash/before/stage/modules.py
+++ b/src/test/python/testModuleHash/before/stage/modules.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import udl as lib
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
 
 class ChangeCode(SmvModule):
@@ -42,6 +42,15 @@ class Upstream(SmvModule):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
+
+class RequiresALibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [lib]
+    def run(self, i):
+        number = lib.getNumber()
+        return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
 
 class Downstream(SmvModule):
     def requiresDS(self):


### PR DESCRIPTION
Fixes #1247

Factor external code's source into DataSet hash.

This is intended to be used with project user-defined libraries but can technically be used on almost any python object (anything that `inspect.getsource()` can be called on).