### PR TITLE
Use libs in hash (no app props)

### DIFF
--- a/docs/user/app_config.md
+++ b/docs/user/app_config.md
@@ -116,13 +116,6 @@ Note that for sequence/list type parameters (e.g. smv.stages), a "," or ":" can 
 </tr>
 
 <tr>
-<td>smv.user_libraries</td>
-<td>empty</td>
-<td>Optional</td>
-<td>A list of external (not SMV DataSet subclass instances) modules, functions and/or objects that should be reloaded with the project</td>
-</tr>
-
-<tr>
 <th colspan="4">Data Directories Parameters</th>
 </tr>
 

--- a/docs/user/app_config.md
+++ b/docs/user/app_config.md
@@ -116,6 +116,13 @@ Note that for sequence/list type parameters (e.g. smv.stages), a "," or ":" can 
 </tr>
 
 <tr>
+<td>smv.user_libraries</td>
+<td>empty</td>
+<td>Optional</td>
+<td>A list of external (not SMV DataSet subclass instances) modules, functions and/or objects that should be reloaded with the project</td>
+</tr>
+
+<tr>
 <th colspan="4">Data Directories Parameters</th>
 </tr>
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -36,9 +36,22 @@ Any of the classes listed above can implement a `requiresLib()` function to defi
 
 This means cached data will be invalidated if the external code is changed, etc.
 
+> **Limitations:** For python modules and packages, the `requiresLib()` method is limited to registering changes on the main file of the package (for module `foo`, that's `foo.py`, for package `bar`, that's `bar/__init__.py`). This means that if a module or package imports other modules, the imported module's changes will not impact DataSet hashes.
+
+There are two steps to setting this up for your project:
+
+1. Add the library to your app conf via either of the files under `conf/` or the command line under the `smv.user_libraries` property.
+
+2. Import the library in all files that depend on it (like `import udl as lib`) and then in the class defs of DataSets that depend on it, implement the `requiresLib()` method and make it return an array of the libraries that that DataSet depends on (for the first example, `requiresLib()` would return `[lib]`).
+
 **Python**
 
 ```py
+# in smv-app-conf.props:
+smv.stages = stage
+smv.user_libraries = lib, pandas
+
+# in src/main/python/stage/someFile.py:
 import some_library as lib
 import pandas
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -20,15 +20,42 @@ directly, instead, they will use all the detailed types of `SmvDataSet`.
 
 In this document we will cover the following basic `SmvDataSet`s,
 
- | Scala | Python
---- | --- | ---
-**Input** | `SmvCsvFile` | `SmvCsvFile`
-          | `SmvMultiCsvFiles` | `SmvMultiCsvFiles`
-          | `SmvCsvStringData` | `SmvCsvStringData`
-          | `SmvHiveTable` | `SmvHiveTable`
-**Intermediate** | `SmvModule` | `SmvModule`
-**Output** (mix in) | `SmvOutput` | `SmvOutput`
+|                     | Scala              | Python             |
+|---------------------|--------------------|--------------------|
+| **Input**           | `SmvCsvFile`       | `SmvCsvFile`       |
+|                     | `SmvMultiCsvFiles` | `SmvMultiCsvFiles` |
+|                     | `SmvCsvStringData` | `SmvCsvStringData` |
+|                     | `SmvHiveTable`     | `SmvHiveTable`     |
+| **Intermediate**    | `SmvModule`        | `SmvModule`        |
+| **Output (mix in)** | `SmvOutput`        | `SmvOutput`        |
+|                     |                    |                    |
 
+### External Code Dependency (python only)
+
+Any of the classes listed above can implement a `requiresLib()` function to define code that isn't SMV DataSets (like an external or user-defined library) that should be considered like it is part of the source of the DataSet itself.
+
+This means cached data will be invalidated if the external code is changed, etc.
+
+**Python**
+
+```py
+import some_library as lib
+import pandas
+
+class MyModule(smv.SmvModule):
+    """mod description"""
+    # define dependency on other SmvDataset(s)
+    def requiresDS(self):
+        return [Mod1, Mod2]
+
+    # define dependency on arbitary external code
+    # ie: libraries defined in your project or from pip
+    def requiresLib(self):
+        return [lib, pandas]
+
+    def run(self, i):
+        ...
+```
 
 ## Input SmvDataSet
 

--- a/docs/user/smv_dataset.md
+++ b/docs/user/smv_dataset.md
@@ -38,20 +38,9 @@ This means cached data will be invalidated if the external code is changed, etc.
 
 > **Limitations:** For python modules and packages, the `requiresLib()` method is limited to registering changes on the main file of the package (for module `foo`, that's `foo.py`, for package `bar`, that's `bar/__init__.py`). This means that if a module or package imports other modules, the imported module's changes will not impact DataSet hashes.
 
-There are two steps to setting this up for your project:
-
-1. Add the library to your app conf via either of the files under `conf/` or the command line under the `smv.user_libraries` property.
-
-2. Import the library in all files that depend on it (like `import udl as lib`) and then in the class defs of DataSets that depend on it, implement the `requiresLib()` method and make it return an array of the libraries that that DataSet depends on (for the first example, `requiresLib()` would return `[lib]`).
-
 **Python**
 
 ```py
-# in smv-app-conf.props:
-smv.stages = stage
-smv.user_libraries = lib, pandas
-
-# in src/main/python/stage/someFile.py:
 import some_library as lib
 import pandas
 

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -204,10 +204,6 @@ class SmvApp(object):
         """Stages is a function as they can be set dynamically on an SmvApp instance"""
         return self.j_smvPyClient.stages()
     
-    def userLibs(self):
-        """Return dynamically set smv.user_libraries from conf"""
-        return self.j_smvPyClient.userLibs()
-
     def appId(self):
         return self.config().appId()
 

--- a/src/main/python/smv/smvdataset.py
+++ b/src/main/python/smv/smvdataset.py
@@ -108,13 +108,14 @@ class SmvDataSet(ABC):
         """
     
     def requiresLib(self):
-        """User-specified list of user-defined (not external) library dependencies
+        """User-specified list of 'library' dependencies. These are code, other than
+            the DataSet's run method that impact its output or behaviour.
 
             Override this method to assist in re-running this module based on changes
-            in other python files.
+            in other python objects (functions, classes, packages).
 
             Returns:
-                (list(Module)): a list of library dependencies
+                (list(module)): a list of library dependencies
         """
         return []
 

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -45,7 +45,6 @@ class SmvApp(private val cmdLineArgs: Seq[String],
   val publishJDBC = smvConfig.cmdLine.publishJDBC()
 
   def stages      = smvConfig.stageNames
-  def userLibs    = smvConfig.userLibs
 
   val sparkConf   = new SparkConf().setAppName(smvConfig.appName)
 

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -208,8 +208,7 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
     "smv.appId"           -> java.util.UUID.randomUUID.toString,
     "smv.stages"          -> "",
     "smv.config.keys"     -> "",
-    "smv.class_dir"       -> "./target/classes",
-    "smv.user_libraries"  -> ""
+    "smv.class_dir"       -> "./target/classes"
   )
 
   // ---------- Dynamic Run Config Parameters key/values ----------
@@ -236,9 +235,6 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
 
   // --- stage names are a dynamic prop
   private[smv] def stageNames = { splitProp("smv.stages").toSeq }
-
-  // --- user libraries are dynamic as well
-  private[smv] def userLibs = { splitProp("smv.user_libraries").toSeq }
 
   val classDir = mergedProps("smv.class_dir")
 

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -262,8 +262,6 @@ class SmvPyClient(val j_smvApp: SmvApp) {
 
   def stages: Array[String] = j_smvApp.stages.toArray
   
-  def userLibs: Array[String] = j_smvApp.userLibs.toArray
-
   def inferDS(name: String): SmvDataSet =
     j_smvApp.dsm.inferDS(name).head
 

--- a/src/test/python/testDynamicConfigAppDir.py
+++ b/src/test/python/testDynamicConfigAppDir.py
@@ -69,7 +69,7 @@ class RunModuleWithDynamicConfigAppDirTest(SmvBaseTest):
 
         # contents of project-a/conf/smv-app-conf.props:
         expected_props = { "smv.class_dir": "./target/classes", "smv.appName": "App A", \
-        "smv.config.keys": "", "smv.stages": "stage", "smv.appId": "PROJECT_A", "smv.user_libraries": "core" }
+        "smv.config.keys": "", "smv.stages": "stage", "smv.appId": "PROJECT_A" }
 
         #  tell the app to change dirs, which should cause the reload of conf for this project
         self.smvApp.setAppDir(self.proj_a_path)

--- a/src/test/python/testDynamicConfigAppDir/project-a/conf/smv-app-conf.props
+++ b/src/test/python/testDynamicConfigAppDir/project-a/conf/smv-app-conf.props
@@ -6,6 +6,3 @@ smv.stages = stage
 
 # static appId for testing
 smv.appId = PROJECT_A
-
-# dummy user_libraries key
-smv.user_libraries = core

--- a/src/test/python/testModuleHash.py
+++ b/src/test/python/testModuleHash.py
@@ -20,7 +20,7 @@ from smv.datasetrepo import DataSetRepo
 class ModuleHashTest(SmvBaseTest):
     @classmethod
     def smvAppInitArgs(cls):
-        return ["--smv-props", "smv.stages=stage", "smv.user_libraries=udl:same"]
+        return ["--smv-props", "smv.stages=stage"]
 
     @classmethod
     def before_dir(cls):

--- a/src/test/python/testModuleHash.py
+++ b/src/test/python/testModuleHash.py
@@ -20,7 +20,7 @@ from smv.datasetrepo import DataSetRepo
 class ModuleHashTest(SmvBaseTest):
     @classmethod
     def smvAppInitArgs(cls):
-        return ["--smv-props", "smv.stages=stage"]
+        return ["--smv-props", "smv.stages=stage", "smv.user_libraries=udl"]
 
     @classmethod
     def before_dir(cls):
@@ -35,13 +35,19 @@ class ModuleHashTest(SmvBaseTest):
             self.dsr = DataSetRepo(smvApp)
             self.path = path
             self.fqn = fqn
+        
+        def lib_path(self):
+            # use a realistic library dir, which we'll also add to py path
+            return self.path + "/library"
 
         def __enter__(self):
             sys.path.insert(1,self.path)
+            sys.path.insert(1,self.lib_path())
             return self.dsr.loadDataSet(self.fqn)
 
         def __exit__(self, type, value, traceback):
             sys.path.remove(self.path)
+            sys.path.remove(self.lib_path())
 
     def compare_resource_hash(self, fqn, assertion):
         with self.Resource(self.smvApp,self.before_dir(),fqn) as ds:
@@ -67,6 +73,10 @@ class ModuleHashTest(SmvBaseTest):
     def test_change_dependency_should_change_hash(self):
         """hash will change if we change module's requiresDS"""
         self.assert_hash_should_change("stage.modules.Dependent")
+    
+    def test_change_required_lib_should_change_hash(self):
+        """hash will change if we modify the source code of a depended-on library"""
+        self.assert_hash_should_change("stage.modules.RequiresALibrary")
 
     def test_change_baseclass_should_change_hash(self):
         """hash will change if we change code for class that module inherits from"""

--- a/src/test/python/testModuleHash/after/library/same.py
+++ b/src/test/python/testModuleHash/after/library/same.py
@@ -1,0 +1,2 @@
+def UnchangedFunction():
+    return "the same thing every time"

--- a/src/test/python/testModuleHash/after/library/udl.py
+++ b/src/test/python/testModuleHash/after/library/udl.py
@@ -1,0 +1,2 @@
+def getNumber(self):
+    return 10

--- a/src/test/python/testModuleHash/after/src/main/python/stage/modules.py
+++ b/src/test/python/testModuleHash/after/src/main/python/stage/modules.py
@@ -11,27 +11,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import udl as lib
+import same as unchanged
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
+
+def sameFunc():
+    """a function which is the same in before/after"""
+    return "I'm the same!"
+
+def differentFunc():
+    """a function that has different source in before/after"""
+    return "I'm in after!"
 
 class ChangeCode(SmvModule):
     def requiresDS(self):
         return []
     def run(self, i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,2")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,3")
 
 class AddComment(SmvModule):
+    # I ADDED A COMMENT, POP!
     def requiresDS(self):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,5")
 
-class DependencyA(SmvModule):
+class DependencyB(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,6")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,215")
 
-class Dependent(DependencyA):
+class Dependent(DependencyB):
     def requiresDS(self):
         return []
     def run(self,i):
@@ -41,9 +51,9 @@ class Upstream(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
 
-class RequiresALibrary(SmvModule):
+class DifferentLibrary(SmvModule):
     def requiresDS(self):
         return []
     def requiresLib(self):
@@ -51,6 +61,34 @@ class RequiresALibrary(SmvModule):
     def run(self, i):
         number = lib.getNumber()
         return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
+
+class SameLibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [unchanged]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', unchanged.UnchangedFunction())
+
+class SameFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [sameFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', sameFunc())
+
+
+class DifferentFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [differentFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', differentFunc())
 
 class Downstream(SmvModule):
     def requiresDS(self):
@@ -62,7 +100,7 @@ class Parent(SmvModule):
     def requiresDS(self):
         return[Upstream]
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,30")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,31")
 
 class HiveTableWithVersion(SmvHiveTable):
     def requiresDS(self):
@@ -70,7 +108,7 @@ class HiveTableWithVersion(SmvHiveTable):
     def tableName(self):
         return "HiveTableWithVersion"
     def version(self):
-        return "1.0"
+        return "1.1"
 
 class CsvFileWithRun(SmvCsvFile):
     def requiresDS(self):
@@ -78,7 +116,7 @@ class CsvFileWithRun(SmvCsvFile):
     def path(self):
         return "foo"
     def run(self, df):
-        return df
+        return df.select("bar")
 
 class Child(Parent):
     pass

--- a/src/test/python/testModuleHash/after/stage/modules.py
+++ b/src/test/python/testModuleHash/after/stage/modules.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import udl as lib
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
 
 class ChangeCode(SmvModule):
@@ -43,6 +43,15 @@ class Upstream(SmvModule):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
+
+class RequiresALibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [lib]
+    def run(self, i):
+        number = lib.getNumber()
+        return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
 
 class Downstream(SmvModule):
     def requiresDS(self):

--- a/src/test/python/testModuleHash/before/library/same.py
+++ b/src/test/python/testModuleHash/before/library/same.py
@@ -1,0 +1,2 @@
+def UnchangedFunction():
+    return "the same thing every time"

--- a/src/test/python/testModuleHash/before/library/udl.py
+++ b/src/test/python/testModuleHash/before/library/udl.py
@@ -1,0 +1,2 @@
+def getNumber(self):
+    return 1

--- a/src/test/python/testModuleHash/before/src/main/python/stage/modules.py
+++ b/src/test/python/testModuleHash/before/src/main/python/stage/modules.py
@@ -11,28 +11,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import udl as lib
+import same as unchanged
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
+
+def sameFunc():
+    """a function which is the same in before/after"""
+    return "I'm the same!"
+
+def differentFunc():
+    """a function that has different source in before/after"""
+    return "I'm in before!"
 
 class ChangeCode(SmvModule):
     def requiresDS(self):
         return []
     def run(self, i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,3")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,2")
 
 class AddComment(SmvModule):
-    # I ADDED A COMMENT, POP!
     def requiresDS(self):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,5")
 
-class DependencyB(SmvModule):
+class DependencyA(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,215")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,6")
 
-class Dependent(DependencyB):
+class Dependent(DependencyA):
     def requiresDS(self):
         return []
     def run(self,i):
@@ -42,9 +50,9 @@ class Upstream(SmvModule):
     def requiresDS(self):
         return []
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,46")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
 
-class RequiresALibrary(SmvModule):
+class DifferentLibrary(SmvModule):
     def requiresDS(self):
         return []
     def requiresLib(self):
@@ -52,6 +60,34 @@ class RequiresALibrary(SmvModule):
     def run(self, i):
         number = lib.getNumber()
         return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
+
+
+class SameLibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [unchanged]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', unchanged.UnchangedFunction())
+
+class SameFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [sameFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', sameFunc())
+
+class DifferentFunc(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [differentFunc]
+    def run(self, i):
+        df = self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3")
+        return df.withColumn('new', differentFunc())
 
 class Downstream(SmvModule):
     def requiresDS(self):
@@ -63,7 +99,7 @@ class Parent(SmvModule):
     def requiresDS(self):
         return[Upstream]
     def run(self,i):
-        return self.smvApp.createDF("k:String;v:Integer", "a,;b,31")
+        return self.smvApp.createDF("k:String;v:Integer", "a,;b,30")
 
 class HiveTableWithVersion(SmvHiveTable):
     def requiresDS(self):
@@ -71,7 +107,7 @@ class HiveTableWithVersion(SmvHiveTable):
     def tableName(self):
         return "HiveTableWithVersion"
     def version(self):
-        return "1.1"
+        return "1.0"
 
 class CsvFileWithRun(SmvCsvFile):
     def requiresDS(self):
@@ -79,7 +115,7 @@ class CsvFileWithRun(SmvCsvFile):
     def path(self):
         return "foo"
     def run(self, df):
-        return df.select("bar")
+        return df
 
 class Child(Parent):
     pass

--- a/src/test/python/testModuleHash/before/stage/modules.py
+++ b/src/test/python/testModuleHash/before/stage/modules.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import udl as lib
 from smv import SmvApp, SmvModule, SmvHiveTable, SmvCsvFile
 
 class ChangeCode(SmvModule):
@@ -42,6 +42,15 @@ class Upstream(SmvModule):
         return []
     def run(self,i):
         return self.smvApp.createDF("k:String;v:Integer", "a,;b,45")
+
+class RequiresALibrary(SmvModule):
+    def requiresDS(self):
+        return []
+    def requiresLib(self):
+        return [lib]
+    def run(self, i):
+        number = lib.getNumber()
+        return self.smvApp.createDF("k:String;v:Integer", "a,1;b,2;c:3").limit(number)
 
 class Downstream(SmvModule):
     def requiresDS(self):


### PR DESCRIPTION
This is the second PR that could fix #1247 

This approach is different because it removes the need to enumerate libraries in the app props _at all_.

Instead, in `DataSetRepo`, we inspect the modules that we are about to pop from `sys.modules` (which we do in order to force python to load new code for the transaction), check their members for `SmvDataSet`(s) and then load those and call their `requiresLib()` method to assemble the list of libraries we also need to pop from `sys.modules`