### PR TITLE
#1269 fix default timestamp format

### DIFF
--- a/docs/user/smv_input.md
+++ b/docs/user/smv_input.md
@@ -212,8 +212,10 @@ other: Decimal[10];
 ### Timestamp type
 The `Timestamp` type can be used to hold a date/timestamp field value.
 An optional format string can be used when defining a field of type `timestamp`.
-The field format is the standard java `java.sql.Timestamp` format string.
+The field format is the standard [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html)
+
 If a format string is not specified, it defaults to `"yyyy-MM-dd HH:mm:ss.S"`.
+Please note the difference between `HH`(Hour in day (0-23)) and `hh`(Hour in am/pm (1-12))
 ```scala
 std_date: Timestamp;
 evt_time: Timestamp[yyyy-MM-dd HH:mm:ss];

--- a/docs/user/smv_input.md
+++ b/docs/user/smv_input.md
@@ -213,7 +213,7 @@ other: Decimal[10];
 The `Timestamp` type can be used to hold a date/timestamp field value.
 An optional format string can be used when defining a field of type `timestamp`.
 The field format is the standard java `java.sql.Timestamp` format string.
-If a format string is not specified, it defaults to `"yyyy-MM-dd hh:mm:ss.S"`.
+If a format string is not specified, it defaults to `"yyyy-MM-dd HH:mm:ss.S"`.
 ```scala
 std_date: Timestamp;
 evt_time: Timestamp[yyyy-MM-dd HH:mm:ss];

--- a/src/main/scala/org/tresamigos/smv/SmvSchema.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvSchema.scala
@@ -125,9 +125,10 @@ private[smv] case class StringTypeFormat(override val format: String = null,
 }
 
 /**
-  * @param format date and time pattern strings defined in Java SimpleDateFormat. See details in
-  *               https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
-  *               Note we are using HH(Hour in day (0-23)) rather than hh(Hour in am/pm (1-12)) in default format
+  * @param format date and time pattern strings defined in Java SimpleDateFormat.
+  *        Note we are using HH(Hour in day (0-23)) rather than hh(Hour in am/pm (1-12)) in default format.
+  *        SimpleDateFormat("yyyy-MM-dd hh:mm:ss.S").parse("2011-09-03 12:13:58.0") returns "2011-09-03 00:13:58"
+  *        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S").parse("2011-09-03 12:13:58.0") returns "2011-09-03 12:13:58"
   */
 private[smv] case class TimestampTypeFormat(override val format: String = "yyyy-MM-dd HH:mm:ss.S")
     extends TypeFormat {

--- a/src/main/scala/org/tresamigos/smv/SmvSchema.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvSchema.scala
@@ -124,7 +124,7 @@ private[smv] case class StringTypeFormat(override val format: String = null,
   val dataType          = StringType
 }
 
-private[smv] case class TimestampTypeFormat(override val format: String = "yyyy-MM-dd hh:mm:ss.S")
+private[smv] case class TimestampTypeFormat(override val format: String = "yyyy-MM-dd HH:mm:ss.S")
     extends TypeFormat {
   // `SimpleDateFormat` is not thread-safe.
   val fmtObj = SmvSchema.threadLocalDateFormat(format).get()

--- a/src/main/scala/org/tresamigos/smv/SmvSchema.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvSchema.scala
@@ -124,6 +124,11 @@ private[smv] case class StringTypeFormat(override val format: String = null,
   val dataType          = StringType
 }
 
+/**
+  * @param format date and time pattern strings defined in Java SimpleDateFormat. See details in
+  *               https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
+  *               Note we are using HH(Hour in day (0-23)) rather than hh(Hour in am/pm (1-12)) in default format
+  */
 private[smv] case class TimestampTypeFormat(override val format: String = "yyyy-MM-dd HH:mm:ss.S")
     extends TypeFormat {
   // `SimpleDateFormat` is not thread-safe.

--- a/src/test/python/testColumnHelper.py
+++ b/src/test/python/testColumnHelper.py
@@ -68,7 +68,7 @@ class ColumnHelperTest(SmvBaseTest):
         r4 = df.select(col("t").smvPlusYears(2).alias("ts"))
         r5 = df.select(col("t").smvPlusYears(4).alias("ts"))
 
-        s = "ts: Timestamp[yyyy-MM-dd hh:mm:ss.S]"
+        s = "ts: Timestamp[yyyy-MM-dd HH:mm:ss.S]"
         e1 = self.createDF(
             s,
             "1976-01-21 00:00:00.0;" +
@@ -104,7 +104,7 @@ class ColumnHelperTest(SmvBaseTest):
         r3 = df.select(col("t").smvPlusMonths(col("toadd")).alias('ts'))
         r4 = df.select(col("t").smvPlusYears(col("toadd")).alias('ts'))
 
-        s = "ts: Timestamp[yyyy-MM-dd hh:mm:ss.S]"
+        s = "ts: Timestamp[yyyy-MM-dd HH:mm:ss.S]"
         e1 = self.createDF(
             s,
             """1976-02-10 00:00:00.0;
@@ -157,7 +157,7 @@ class ColumnHelperTest(SmvBaseTest):
             df.smvTime.smvTimeToTimestamp()
         )
 
-        e = self.createDF("smvTime: String;type: String;index: Integer;label: String;timestamp: Timestamp[yyyy-MM-dd hh:mm:ss.S]",
+        e = self.createDF("smvTime: String;type: String;index: Integer;label: String;timestamp: Timestamp[yyyy-MM-dd HH:mm:ss.S]",
                         """D20120302,day,15401,2012-03-02,2012-03-02 00:00:00.0;
                             Q201203,quarter,170,2012-Q3,2012-07-01 00:00:00.0;
                             M201203,month,506,2012-03,2012-03-01 00:00:00.0;

--- a/src/test/scala/org/tresamigos/smv/ColumnHelperTest.scala
+++ b/src/test/scala/org/tresamigos/smv/ColumnHelperTest.scala
@@ -100,7 +100,7 @@ class ColumnHelperTest extends SmvTestUtil {
     val res4 = df.select($"t".smvPlusYears(2))
     val res5 = df.select($"t".smvPlusYears(4))
 
-    assertSrddSchemaEqual(res1, "SmvPlusDays(t, -10): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res1, "SmvPlusDays(t, -10): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res1,
                         "1976-01-21 00:00:00.0;" +
                           "2012-02-19 00:00:00.0")
@@ -128,7 +128,7 @@ class ColumnHelperTest extends SmvTestUtil {
     val res4 = df.select($"t".smvPlusYears(2))
     val res5 = df.select($"t".smvPlusYears(4))
 
-    assertSrddSchemaEqual(res1, "SmvPlusDays(t, -10): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res1, "SmvPlusDays(t, -10): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res1,
                         "1976-01-21 00:00:00.0;" +
                           "2012-02-19 00:00:00.0")
@@ -154,25 +154,25 @@ class ColumnHelperTest extends SmvTestUtil {
     val res3 = df.select(col("t").smvPlusMonths(col("toadd")))
     val res4 = df.select(col("t").smvPlusYears(col("toadd")))
 
-    assertSrddSchemaEqual(res1, "SmvPlusDays(t, toadd): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res1, "SmvPlusDays(t, toadd): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res1,
                         """1976-02-10 00:00:00.0;
                            2012-04-01 00:00:00.0;
                            null"""
                        )
-    assertSrddSchemaEqual(res2, "SmvPlusWeeks(t, toadd): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res2, "SmvPlusWeeks(t, toadd): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res2,
                         """1976-04-10 00:00:00.0;
                            2012-10-10 00:00:00.0;
                            null"""
                        )
-    assertSrddSchemaEqual(res3, "SmvPlusMonths(t, toadd): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res3, "SmvPlusMonths(t, toadd): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res3,
                         """1976-11-30 00:00:00.0;
                            2014-10-29 00:00:00.0;
                            null"""
                        )
-    assertSrddSchemaEqual(res4, "SmvPlusYears(t, toadd): Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    assertSrddSchemaEqual(res4, "SmvPlusYears(t, toadd): Timestamp[yyyy-MM-dd HH:mm:ss.S]")
     assertSrddDataEqual(res4,
                         """1986-01-31 00:00:00.0;
                            2044-02-29 00:00:00.0;

--- a/src/test/scala/org/tresamigos/smv/SchemaTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SchemaTest.scala
@@ -162,9 +162,17 @@ class SmvSchemaTest extends SmvTestUtil {
   }
 
   test("Test Timestamp default format") {
-    val df = dfFrom("a:Timestamp", "2011-09-03 10:13:58.0")
-    assert(df.collect()(0)(0).toString === "2011-09-03 10:13:58.0")
-    assert(SmvSchema.fromDataFrame(df).toString === "Schema: a: Timestamp[yyyy-MM-dd hh:mm:ss.S]")
+    val df = dfFrom("a:Timestamp", "2011-09-03 00:13:58.0;2011-09-03 01:13:58.0;2011-09-03 11:13:58.0;" +
+      "2011-09-03 12:13:58.0;2011-09-03 13:13:58.0;2011-09-03 23:13:58.0;2011-09-03 24:13:58.0")
+
+    assert(df.collect()(0)(0).toString === "2011-09-03 00:13:58.0")
+    assert(df.collect()(1)(0).toString === "2011-09-03 01:13:58.0")
+    assert(df.collect()(2)(0).toString === "2011-09-03 11:13:58.0")
+    assert(df.collect()(3)(0).toString === "2011-09-03 12:13:58.0")
+    assert(df.collect()(4)(0).toString === "2011-09-03 13:13:58.0")
+    assert(df.collect()(5)(0).toString === "2011-09-03 23:13:58.0")
+    assert(df.collect()(6)(0).toString === "2011-09-04 00:13:58.0")
+    assert(SmvSchema.fromDataFrame(df).toString === "Schema: a: Timestamp[yyyy-MM-dd HH:mm:ss.S]")
   }
 
   test("Test Date default format") {


### PR DESCRIPTION
Fixes #1269. 

Use "yyyy-MM-dd HH:mm:ss.S" as default SMV timestamp format instead of `"yyyy-MM-dd hh:mm:ss.S"`