### PR TITLE
I1324 spark dir env var

### DIFF
--- a/tools/smv-install
+++ b/tools/smv-install
@@ -38,6 +38,8 @@ function parse_args()
   SMV_PROFILE_FILENAME="smv-profile.sh"
   SMV_PROFILE="${HOME}/.smv/${SMV_PROFILE_FILENAME}"
 
+  SPARK_DIR="Spark"
+
   validate_version
 }
 
@@ -95,7 +97,7 @@ download_smv() {
 
 # Download prebuilt spark version with hive support.
 download_spark() {
-  "${SMV_DIR}/tools/spark-install"
+  "${SMV_DIR}/tools/spark-install --target-dir ${SPARK_DIR}" 
 }
 
 jre_installtion_validation() {

--- a/tools/smv-install
+++ b/tools/smv-install
@@ -97,7 +97,7 @@ download_smv() {
 
 # Download prebuilt spark version with hive support.
 download_spark() {
-  "${SMV_DIR}/tools/spark-install --target-dir ${SPARK_DIR}" 
+  ${SMV_DIR}/tools/spark-install --target-dir ${SPARK_DIR}
 }
 
 jre_installtion_validation() {


### PR DESCRIPTION
Fixed #1324 

Instead of let `spark-install` to specify the `SPARK_DIR`, let `smv-install` to specify it as `Spark`. 

Tested by:
```
curl https://raw.githubusercontent.com/TresAmigosSD/SMV/i1324_spark_dir_env_var/tools/smv-install | bash -s -- -spark
```