### PR TITLE
I1293 fix version number matching

### DIFF
--- a/admin/smv-release
+++ b/admin/smv-release
@@ -58,6 +58,9 @@ function parse_args()
     exit 1
   fi
 
+  # transform the version number to a regex-friendly format
+  SMV_VERSION_REG=${SMV_VERSION//./\\.}
+
   # version specific vars
   LOGFILE="${BUILD_DIR}/smv-release.log"
   rm -f "${LOGFILE}"
@@ -105,6 +108,9 @@ function get_prev_smv_version()
 {
   PREV_SMV_VERSION=$(cat "${SMV_DIR}/.smv_version")
   info "previous SMV version: $PREV_SMV_VERSION"
+
+  # transform the version number to a regex-friendly format
+  PREV_SMV_VERSION_REG=${PREV_SMV_VERSION//./\\.}
 }
 
 # make sure version is of the format a.b.c.d where a,b,c,d are all numbers.
@@ -167,16 +173,16 @@ function update_version()
 
   # update version in user docs.
   find docs/user -name '*.md' \
-    -exec perl -pi -e "s/${PREV_SMV_VERSION}/${SMV_VERSION}/g" \{\} +
+    -exec perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" \{\} +
 
   # update version in README file
-  perl -pi -e "s/${PREV_SMV_VERSION}/${SMV_VERSION}/g" README.md
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" README.md
 
   # update version in Dockerfile
-  perl -pi -e "s/${PREV_SMV_VERSION}/${SMV_VERSION}/g" docker/smv/Dockerfile
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" docker/smv/Dockerfile
 
   # update version in smv-install
-  perl -pi -e "s/${PREV_SMV_VERSION}/${SMV_VERSION}/g" tools/smv-install
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" tools/smv-install
 
   # add the smv version to the SMV directory.
   echo ${SMV_VERSION} > "${SMV_DIR}/.smv_version"
@@ -342,7 +348,7 @@ function update_ghpages_docs()
     info "WARNING!!!! need to update ghpages index.html manually"
   else
     info "updating version numbers in ghpages index.html"
-    sed -i'.bak' "s/${PREV_SMV_VERSION}/${SMV_VERSION}/g" index.html
+    sed -i'.bak' "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" index.html
     rm -f index.html.bak
   fi
 }

--- a/admin/smv-release
+++ b/admin/smv-release
@@ -58,9 +58,6 @@ function parse_args()
     exit 1
   fi
 
-  # transform the version number to a regex-friendly format
-  SMV_VERSION_REG=${SMV_VERSION//./\\.}
-
   # version specific vars
   LOGFILE="${BUILD_DIR}/smv-release.log"
   rm -f "${LOGFILE}"
@@ -173,16 +170,16 @@ function update_version()
 
   # update version in user docs.
   find docs/user -name '*.md' \
-    -exec perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" \{\} +
+    -exec perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION}/g" \{\} +
 
   # update version in README file
-  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" README.md
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION}/g" README.md
 
   # update version in Dockerfile
-  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" docker/smv/Dockerfile
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION}/g" docker/smv/Dockerfile
 
   # update version in smv-install
-  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" tools/smv-install
+  perl -pi -e "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION}/g" tools/smv-install
 
   # add the smv version to the SMV directory.
   echo ${SMV_VERSION} > "${SMV_DIR}/.smv_version"
@@ -348,7 +345,7 @@ function update_ghpages_docs()
     info "WARNING!!!! need to update ghpages index.html manually"
   else
     info "updating version numbers in ghpages index.html"
-    sed -i'.bak' "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION_REG}/g" index.html
+    sed -i'.bak' "s/${PREV_SMV_VERSION_REG}/${SMV_VERSION}/g" index.html
     rm -f index.html.bak
   fi
 }

--- a/docs/user/dqm.md
+++ b/docs/user/dqm.md
@@ -47,7 +47,7 @@ An example parsing validation log is like the following
     "java.text.ParseException: Unparseable date: \"109130619\" @RECORD: 123,12.50  ,109130619,12102012",
     "java.text.ParseException: Unparseable date: \"201309130619\" @RECORD: 123,12.50  ,201309130619,12102012",
     "java.lang.IllegalArgumentException: requirement failed @RECORD: 123,12.50  ,12102012",
-    "java.lang.NumberFormatException: For input string: \"001x\" @RECORD: 123,001x  ,2.3.0.09130619,12102012"
+    "java.lang.NumberFormatException: For input string: \"001x\" @RECORD: 123,001x  ,20130109130619,12102012"
   ]
 }
 ```

--- a/docs/user/edd.md
+++ b/docs/user/edd.md
@@ -41,7 +41,7 @@ EMP                  Null Count             0
 EMP                  Average                2170425.7884615385
 EMP                  Standard Deviation     2330941.3442028034
 EMP                  Min                    202724.0
-EMP                  Max                    1.2.3.0.0E7
+EMP                  Max                    1.2319102E7
 ```
 
 Boolean type column

--- a/docs/user/smv_timepanel.md
+++ b/docs/user/smv_timepanel.md
@@ -52,7 +52,7 @@ Day(2012, 1, 2)
 Attributes:
 * `timeType` - "day"
 * `timeIndex` - 15341
-* `smvTime` - "D2.3.0.02"
+* `smvTime` - "D20120102"
 * `timeLabel` - "2012-01-02"
 
 ### Month
@@ -95,7 +95,7 @@ Week(2012, 1, 2)
 Attributes:
 * `timeType` - "week"
 * `timeIndex` - 2192
-* `smvTime` - "W2.3.0.02"
+* `smvTime` - "W20120102"
 * `timeLabel` - "Week of 2012-01-02"
 
 In the custom start of week case,
@@ -106,7 +106,7 @@ Week(2012, 1, 2, "Sunday")
 Attributes:
 * `timeType` - "week_start_on_Sunday"
 * `timeIndex` - 2192
-* `smvTime` - "W(7)2.3.0.01"
+* `smvTime` - "W(7)20120101"
 * `timeLabel` - "Week of 2012-01-01"
 
 


### PR DESCRIPTION
Fixes #1293 
When updating smv version number in the docs, each dot `.` in `SMV_VERSION` will be parsed to `\.` to match the actual dot instead of an regex wildcard. e.g. `/2.3.0.0/g` -> `/2\.3\.0\.0/g`.

I have tested these changes manually by entering the `perl -pi -e` commands, but a full test would require making a new release. Shall we make a release to test this?