### PR TITLE
Add 1st column value as column description to schemaDiscovery

### DIFF
--- a/src/main/scala/org/tresamigos/smv/SchemaDiscoveryHelper.scala
+++ b/src/main/scala/org/tresamigos/smv/SchemaDiscoveryHelper.scala
@@ -184,7 +184,7 @@ class SchemaDiscoveryHelper(sqlContext: SQLContext) {
 
     val res =
       new SmvSchema(columns.zip(typeFmts).zip(firstValidRec).map { 
-        case ((n, t), r) => SchemaEntry(n, t, new SmvKeys().createMetaWithDesc(r))
+        case ((n, t), r) => SchemaEntry(n, t, SmvKeys.createMetaWithDesc(r))
       }, Map.empty)
 
     res.addCsvAttributes(ca)

--- a/src/main/scala/org/tresamigos/smv/SchemaDiscoveryHelper.scala
+++ b/src/main/scala/org/tresamigos/smv/SchemaDiscoveryHelper.scala
@@ -153,7 +153,7 @@ class SchemaDiscoveryHelper(sqlContext: SQLContext) {
     val rowsToParse = noHeadRDD.take(numLines)
 
     var validCount = 0
-    //abstract first valid record to be used in the discovered schema as the columne description
+    //extract first valid record to be used in the discovered schema as the columne description
     var firstValidRec = new Array[String](columns.length)
     for (rowStr <- rowsToParse) {
       val rowValues = Try { parser.parseLine(rowStr) }.getOrElse(Array[String]())

--- a/src/main/scala/org/tresamigos/smv/SchemaMetaOps.scala
+++ b/src/main/scala/org/tresamigos/smv/SchemaMetaOps.scala
@@ -1,0 +1,122 @@
+/*
+ * This file is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tresamigos.smv
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.Metadata
+import org.tresamigos.smv.SmvKeys._
+
+private[smv] class SchemaMetaOps(df: DataFrame) {
+
+  /**
+   * Adds labels to the specified columns.
+   *
+   * A column may have multiple labels.  Adding the same label twice
+   * to a column has the same effect as adding that label once.
+   *
+   * For multiple colNames, the same set of labels will be added to all of them.
+   * When colNames is empty, the set of labels will be added to all columns of the df.
+   * labels parameters must be non-empty.
+   */
+  def addLabel(colNames: Seq[String], labels: Seq[String]): DataFrame = {
+    require(!labels.isEmpty)
+    val allCol = colNames.isEmpty
+
+    val columns = df.schema.fields map { f =>
+      val c = f.name
+
+      // if new label should be added to this column. Add to all columns, if colNames is empty
+      if (allCol || colNames.contains(c)) {
+        val meta = addLabelsToMeta(f.metadata, labels)
+        df(c).as(c, meta)
+      } else df(f.name)
+    }
+
+    df.select(columns: _*)
+  }
+
+  def addDesc(colDescs: Seq[(String, String)]): DataFrame = {
+    require(!colDescs.isEmpty)
+    val colMap = colDescs.toMap
+
+    val columns = df.schema.fields map { f =>
+      val c = f.name
+      if (colMap.contains(c)) {
+        val meta = addDescToMeta(f.metadata, colMap.getOrElse(c, ""))
+        df(c).as(c, meta)
+      } else df(c)
+    }
+
+    df.select(columns: _*)
+  }
+
+  def getLabel(colName: String): Seq[String] = {
+    getMetaLabels(df.schema.apply(colName).metadata)
+  }
+
+  def getDesc(colName: String): String = {
+    getMetaDesc(df.schema.apply(colName).metadata)
+  }
+
+  def removeLabel(colNames: Seq[String], labels: Seq[String]): DataFrame = {
+    val allCol    = colNames.isEmpty
+
+    val columns = df.schema.fields map { f =>
+      val c = f.name
+      if (allCol || colNames.contains(c)) {
+        val meta = removeLabelsFromMeta(f.metadata, labels)
+        df(c) as (c, meta)
+      } else df(c)
+    }
+    df.select(columns: _*)
+  }
+
+  def removeDesc(colNames: Seq[String]): DataFrame = {
+    val allCol = colNames.isEmpty
+
+    val columns = df.schema.fields map { f =>
+      val c = f.name
+      if (allCol || colNames.contains(c)) {
+        val meta    = removeDescFromMeta(f.metadata)
+        df(c) as (c, meta)
+      } else df(c)
+    }
+    df.select(columns: _*)
+  }
+
+  def colWithLabel(labels: Seq[String]): Seq[String] = {
+    val filterFn: Metadata => Boolean = { meta =>
+      if (labels.isEmpty)
+        !meta.contains(SmvLabel) || meta.getStringArray(SmvLabel).isEmpty
+      else
+        meta.contains(SmvLabel) && labels.toSet.subsetOf(meta.getStringArray(SmvLabel).toSet)
+    }
+
+    val ret = for {
+      f <- df.schema.fields if (filterFn(f.metadata))
+    } yield f.name
+
+    require(
+      !ret.isEmpty,
+      if (labels.isEmpty)
+        s"""there are no unlabeled columns in the data frame [${df.columns.mkString(",")}]"""
+      else
+        s"""there are no columns labeled with ${labels} in the data frame [${df.columns.mkString(
+          ",")}]"""
+    )
+
+    ret
+  }
+}

--- a/src/main/scala/org/tresamigos/smv/SmvKeys.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvKeys.scala
@@ -57,12 +57,6 @@ private[smv] class SmvKeys {
   }
 }
 
-private[smv] class FieldMetaOps(f: StructField) extends SmvKeys {
-  def addDesc(desc: String) = {
-    new StructField(f.name, f.dataType, f.nullable, f.metadata)
-  }
-}
-
 private[smv] class SchemaMetaOps(df: DataFrame) extends SmvKeys {
 
   /**

--- a/src/main/scala/org/tresamigos/smv/SmvKeys.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvKeys.scala
@@ -14,10 +14,11 @@
 
 package org.tresamigos.smv
 
-import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
 
-private[smv] class SmvKeys {
+/** Utility for using the metadata part of StructField to store Smv keys 
+ */
+private[smv] object SmvKeys {
   val SmvLabel = "smvLabel"
   val SmvDesc  = "smvDesc"
 
@@ -54,108 +55,5 @@ private[smv] class SmvKeys {
   def removeDescFromMeta(m: Metadata): Metadata = {
     val builder = new MetadataBuilder().withMetadata(m)
     builder.putString(SmvDesc, "").build
-  }
-}
-
-private[smv] class SchemaMetaOps(df: DataFrame) extends SmvKeys {
-
-  /**
-   * Adds labels to the specified columns.
-   *
-   * A column may have multiple labels.  Adding the same label twice
-   * to a column has the same effect as adding that label once.
-   *
-   * For multiple colNames, the same set of labels will be added to all of them.
-   * When colNames is empty, the set of labels will be added to all columns of the df.
-   * labels parameters must be non-empty.
-   */
-  def addLabel(colNames: Seq[String], labels: Seq[String]): DataFrame = {
-    require(!labels.isEmpty)
-    val allCol = colNames.isEmpty
-
-    val columns = df.schema.fields map { f =>
-      val c = f.name
-
-      // if new label should be added to this column. Add to all columns, if colNames is empty
-      if (allCol || colNames.contains(c)) {
-        val meta = addLabelsToMeta(f.metadata, labels)
-        df(c).as(c, meta)
-      } else df(f.name)
-    }
-
-    df.select(columns: _*)
-  }
-
-  def addDesc(colDescs: Seq[(String, String)]): DataFrame = {
-    require(!colDescs.isEmpty)
-    val colMap = colDescs.toMap
-
-    val columns = df.schema.fields map { f =>
-      val c = f.name
-      if (colMap.contains(c)) {
-        val meta = addDescToMeta(f.metadata, colMap.getOrElse(c, ""))
-        df(c).as(c, meta)
-      } else df(c)
-    }
-
-    df.select(columns: _*)
-  }
-
-  def getLabel(colName: String): Seq[String] = {
-    getMetaLabels(df.schema.apply(colName).metadata)
-  }
-
-  def getDesc(colName: String): String = {
-    getMetaDesc(df.schema.apply(colName).metadata)
-  }
-
-  def removeLabel(colNames: Seq[String], labels: Seq[String]): DataFrame = {
-    val allCol    = colNames.isEmpty
-
-    val columns = df.schema.fields map { f =>
-      val c = f.name
-      if (allCol || colNames.contains(c)) {
-        val meta = removeLabelsFromMeta(f.metadata, labels)
-        df(c) as (c, meta)
-      } else df(c)
-    }
-    df.select(columns: _*)
-  }
-
-  def removeDesc(colNames: Seq[String]): DataFrame = {
-    val allCol = colNames.isEmpty
-
-    val columns = df.schema.fields map { f =>
-      val c = f.name
-      if (allCol || colNames.contains(c)) {
-        val meta    = removeDescFromMeta(f.metadata)
-        df(c) as (c, meta)
-      } else df(c)
-    }
-    df.select(columns: _*)
-  }
-
-  def colWithLabel(labels: Seq[String]): Seq[String] = {
-    val filterFn: Metadata => Boolean = { meta =>
-      if (labels.isEmpty)
-        !meta.contains(SmvLabel) || meta.getStringArray(SmvLabel).isEmpty
-      else
-        meta.contains(SmvLabel) && labels.toSet.subsetOf(meta.getStringArray(SmvLabel).toSet)
-    }
-
-    val ret = for {
-      f <- df.schema.fields if (filterFn(f.metadata))
-    } yield f.name
-
-    require(
-      !ret.isEmpty,
-      if (labels.isEmpty)
-        s"""there are no unlabeled columns in the data frame [${df.columns.mkString(",")}]"""
-      else
-        s"""there are no columns labeled with ${labels} in the data frame [${df.columns.mkString(
-          ",")}]"""
-    )
-
-    ret
   }
 }

--- a/src/main/scala/org/tresamigos/smv/SmvKeys.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvKeys.scala
@@ -17,16 +17,21 @@ package org.tresamigos.smv
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
 
-private[smv] abstract class SmvKeys {
+private[smv] class SmvKeys {
   val SmvLabel = "smvLabel"
   val SmvDesc  = "smvDesc"
 
-  protected def getMetaDesc(m: Metadata): String = {
+  def getMetaDesc(m: Metadata): String = {
     if (m.contains(SmvDesc)) m.getString(SmvDesc) else ""
   }
 
-  protected def getMetaLabels(m: Metadata): Seq[String] = {
+  def getMetaLabels(m: Metadata): Seq[String] = {
     if (m.contains(SmvLabel)) m.getStringArray(SmvLabel).toSeq else Seq.empty
+  }
+
+  def createMetaWithDesc(desc: String): Metadata = {
+    val builder = new MetadataBuilder()
+    builder.putString(SmvDesc, desc).build
   }
 
   def addDescToMeta(m: Metadata, desc: String): Metadata = {

--- a/src/main/scala/org/tresamigos/smv/SmvSchema.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvSchema.scala
@@ -19,7 +19,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.DataFrame
-
+ 
 import java.sql.Date
 import java.text.{DateFormat, SimpleDateFormat}
 
@@ -323,12 +323,12 @@ object SchemaEntry {
     SchemaEntry(structField, typeFmt)
   }
 
-  def apply(name: String, typeFmt: TypeFormat): SchemaEntry = {
-    val field = StructField(name, typeFmt.dataType, true)
+  def apply(name: String, typeFmt: TypeFormat, meta: Metadata = new MetadataBuilder().build): SchemaEntry = {
+    val field = StructField(name, typeFmt.dataType, true, meta)
     SchemaEntry(field, typeFmt)
   }
 
-  def apply(name: String, typeFmtStr: String, meta: String = null): SchemaEntry = {
+  def apply(name: String, typeFmtStr: String, meta: String): SchemaEntry = {
     val typeFmt  = TypeFormat(typeFmtStr)
     val metaData = if (meta == null) Metadata.empty else Metadata.fromJson(meta)
     val field    = StructField(name, typeFmt.dataType, true, metaData)

--- a/src/test/resources/data/SchemaDiscoveryTest/test6.csv
+++ b/src/test/resources/data/SchemaDiscoveryTest/test6.csv
@@ -1,0 +1,3 @@
+id,name,age
+1,bob,
+3,alice,66

--- a/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
@@ -110,12 +110,13 @@ class SchemaDiscoveryTest extends SmvTestUtil {
   }
 
   test("Test schema discovery with first record as desc") {
-    val strRDD  = sqlContext.sparkContext.textFile(testDataDir + "SchemaDiscoveryTest/test4.csv")
+    val strRDD  = sqlContext.sparkContext.textFile(testDataDir + "SchemaDiscoveryTest/test6.csv")
     val helper  = new SchemaDiscoveryHelper(sqlContext)
     val schema  = helper.discoverSchema(strRDD, 10, CsvAttributes.defaultCsvWithHeader)
     val entries = schema.entries
 
     assert(SmvKeys.getMetaDesc(schema.toStructType.apply("name").metadata) === "bob")
+    assert(SmvKeys.getMetaDesc(schema.toStructType.apply("age").metadata) === "66")
   }
 
   test("Test basic getTypeFormat Timestamp discovery") {

--- a/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
@@ -109,6 +109,15 @@ class SchemaDiscoveryTest extends SmvTestUtil {
     }
   }
 
+  test("Test schema discovery with first record as desc") {
+    val strRDD  = sqlContext.sparkContext.textFile(testDataDir + "SchemaDiscoveryTest/test4.csv")
+    val helper  = new SchemaDiscoveryHelper(sqlContext)
+    val schema  = helper.discoverSchema(strRDD, 10, CsvAttributes.defaultCsvWithHeader)
+    val entries = schema.entries
+
+    assert(new SmvKeys().getMetaDesc(schema.toStructType.apply("name").metadata) === "bob")
+  }
+
   test("Test basic getTypeFormat Timestamp discovery") {
     val helper = new SchemaDiscoveryHelper(sqlContext)
     assert(helper.getTypeFormat(null, "12/06/2012 10:22:14.0") === TimestampTypeFormat("MM/dd/yyyy HH:mm:ss.S"))

--- a/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SchemaDiscoveryTest.scala
@@ -115,7 +115,7 @@ class SchemaDiscoveryTest extends SmvTestUtil {
     val schema  = helper.discoverSchema(strRDD, 10, CsvAttributes.defaultCsvWithHeader)
     val entries = schema.entries
 
-    assert(new SmvKeys().getMetaDesc(schema.toStructType.apply("name").metadata) === "bob")
+    assert(SmvKeys.getMetaDesc(schema.toStructType.apply("name").metadata) === "bob")
   }
 
   test("Test basic getTypeFormat Timestamp discovery") {


### PR DESCRIPTION
Fixed #74 

* Split original `SmvKeys.scala` file to `SmvKeys.scala` and `SchemaMetaOps.scala` files
* Made `SmvKeys` an object for all the utility methods used for StructField metadata operations
* Added first recode in SchemaDiscovery process to be the SmvDesc for the discovered Schema file

A result:
```
@delimiter = ,
@has-header = true
@quote-char = "
id: Integer @metadata={"smvDesc":"1"}
name: String @metadata={"smvDesc":"Scott"}
age: Integer @metadata={"smvDesc":"19"}
weight: Float @metadata={"smvDesc":"160.98"}
active: Boolean @metadata={"smvDesc":"true"}
address: String @metadata={"smvDesc":""}
registration_date: Date[yyyy-MM-dd] @metadata={"smvDesc":"2012-08-03"}
last_active_date: Date[yyyyMMdd] @metadata={"smvDesc":"20140930"}
last_active_time: Timestamp[yyyy-MM-dd HH:mm:ss] @metadata={"smvDesc":"2014-09-03 14:36:15"}
```