### PR TITLE
#1365: added smv result class/docs

### DIFF
--- a/docs/dev/DataSetMgr/DataSetMgr_class.puml
+++ b/docs/dev/DataSetMgr/DataSetMgr_class.puml
@@ -54,8 +54,8 @@ package Scala {
       run(i: runParams): DataFrame
       resolvedRequiresDS: Seq[SmvDataSet]
     }
-    class SmvExtModulePython -|> SmvModule
-    class SmvModule -L|> SmvDataSet
+    SmvExtModulePython -|> SmvModule
+    SmvModule -L|> SmvDataSet
   }
   class SmvExtModule extends SmvModule
   class SmvModuleLink extends SmvModule

--- a/docs/dev/SmvResult/SmvResult.md
+++ b/docs/dev/SmvResult/SmvResult.md
@@ -2,10 +2,41 @@
 
 There are circumstances in which it would be useful for an `SmvModule` to return a result which is not a `DataFrame`. For example, when using SMV for modeling it would be helpful to train the model in one module and score data with the model in another module downstream. In this scenario, we would also like to persist the model as an intermediate result as we would with a `DataFrame`.
 
-## Pickle & persist
+We currently handle the "model" special case by converting the model result into a string (by pickle) and stuffing that into a single row `DataFrame`.
+This approach will not scale to other types well.  For example, we would like to support "generic" modules that may depend-on and return types such
+as Pandas data, H2O data, none-serializable models, etc.
 
-If possible, we would like to use the same mechanisms for persisting these generic results as we do for persisting `DataFrames`. We can accomplish this by serializing the user's result and saving the serialization as a single row `DataFrame`. Since this feature is only needed for Python `SmvModules`, we can use `pickle` for the serialization of arbitrary results. Of course, this requires that the result is safely picklable.
+# Solution
+The solution is to wrap all module results into a concrete implementation of `SmvResult` class.
+`SmvResult`s would be responsible for persisting/reading result data.  The `SmvModule` will no longer assume results/inputs are Spark `DataFrame`.
 
-## SmvResultModule
+Each concrete `SmvModule` type would have to specify the corresponding `SmvResult` class that can handle the result of it's `run` method.
+The current `SmvModule` can continue to be specific to Spark modules and can be bound to `SmvDataframeResult` result.
+Other modules types can specify different result types.
+For example, `SmvPandasModule` can specify `SmvPandasResult` as it's result type.
+Downstream modules that depend on a instance of `SmvPandasModule` can assume that they will receive a pandas `DataFrame` as input.
 
-When the result is read back as an input, we need some indication that the `DataFrame` contains a pickled object. Modules that return generic results will inherit from `SmvResultModule` (name will probably be updated upon further consideration).
+## Example client code
+```python
+class M1_S(SmvModule):
+   """This is a spark dataframe module"""
+   def run(i):
+     return DataFrame(...) # spark dataframe
+
+class M2_P(SmvPandasModule):
+   """This is a pandas dataframe module"""
+   def run(i):
+     return pandas.createDataFrame(...) # pandas dataframe
+
+class M3_J(SmvModule):
+   """spark module that combines pandas+spark dataframes"""
+   def requiresDS(): return [ M1_S, M1_P ]
+   def run(i):
+      s = i[M1_S] # this is a spark DataFrame
+      p = i[M1_P] # this is a pandas DataFrame
+
+      return s.join(p.toSpark(), ...) # spark dataframe
+```
+
+**Note:** user code doesn't know or see any reference to `SmvResult`.
+By the time the `run()` method is called, the raw results are extracted from `SmvResult`

--- a/docs/dev/SmvResult/smv_result.puml
+++ b/docs/dev/SmvResult/smv_result.puml
@@ -1,0 +1,35 @@
+@startuml
+
+hide empty methods
+hide empty fields
+hide circle
+
+together {
+class SmvResult {
+  ctor(_info, _rawData)
+  rawData()
+  persist()
+  <<static>> unpersist(_info)
+}
+note left: _info: meta info about result\n     (e.g. fqn, version, etc)\n_rawData: the raw result data\n     (e.g. DataFrame, Panda, ...)
+
+class SmvDataFrameResult extends SmvResult
+class SmvPandasResult extends SmvResult
+}
+
+class SmvGenericModule {
+  <<abstract>> def run(i) : Any
+  <<abstract>> def resultType() : SmvResult
+}
+
+class SmvModule extends SmvGenericModule {
+  def resultType() : return SmvDataFrameResult
+}
+SmvModule ..> "generates" SmvDataFrameResult
+
+class SmvPandasModule extends SmvGenericModule {
+  def resultType() : return SmvPandasResult
+}
+SmvPandasModule ..> "generates" SmvPandasResult
+
+@enduml


### PR DESCRIPTION
Design for `SmvResult` class.  The plantuml in PR is shown below as well:

![class_diagram](http://www.plantuml.com/plantuml/png/fL31IWCn4BtdAuQUTc791oobL10z2Q8U2oLDPjj0Dgd9f5fA_zraJUsgwyazlNrvyzwRMGOIdc9ls4uh1EptT8GUQUTK65ETHdDXfFRI86Fajac87avC6X42FFU79mpHK68093bVhRNjN0DhBzvk1OawyGLM6U_H1nremFDvwa9QBXOGRNdudA_PcLb720OxQc7WsjnIG8OWDYuI-25wPI5_5V8jX-xLDd38LYu195clxALA2xH3I3zb45GYlqrdrPqNFJRmAAmI3N3EQtPTzajGjiPtGgj6TxXA1uFmf-uyShr7YrxB1wUYGJWDbn6RG5v8IhTHs86Fjj8rj71ZZvFlW-lBSOzLLatdb81IPZfvmimZHMydra_cLrVE5p3RPZz166PJyf_7-M-VOZCgKvZfIhycbYaszkO3)

There are a couple of possible variations/TBD:
* Make current `SmvModule` the base class instead of adding `SmvGenericModule`.
* add a `canPersist()` method to `SmvResult` that would notify SMV that these types of results can not be persisted so therefore can not have `isEphermeral()` set to false.
* move the `persist`/`unpersist` into the module itself (still add the methods though).  Less classes to maintain but harder to reuse persistence engines (e.g. we can just have a generic `PickleResult` mix-in that all serializable types can use directly).  Then again that can be mixed in into the `*Module` ass as well

