### PR TITLE
I1370 last step - moved run to python

### DIFF
--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -190,34 +190,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
   }
 
   /**
-   * execute as dry-run if the dry-run flag is specified.
-   * This will show which modules are not yet persisted that need to run, without
-   * actually running the modules.
-   * @return true if dry-run option was specified, otherwise false
-   */
-  private[smv] def dryRun(): Boolean = {
-    if (smvConfig.cmdLine.dryRun()) {
-
-      // find all ancestors inclusive,
-      // filter the modules that are not yet persisted and not ephemeral.
-      // this yields all the modules that will need to be run with the given command
-      val modsNotPersisted = modulesToRun.flatMap( m =>
-        m +: m.ancestors
-      ).filterNot(m =>
-        m.isPersisted || m.isEphemeral
-      ).distinct
-
-      println("Dry run - modules not persisted:")
-      println("----------------------")
-      println(modsNotPersisted.mkString("\n"))
-      println("----------------------")
-      true
-    } else {
-      false
-    }
-  }
-
-  /**
    * if the publish to hive flag is setn, the publish
    */
   def publishModulesToHive(collector: SmvRunInfoCollector): Boolean = {

--- a/src/test/python/testRunCmdLine.py
+++ b/src/test/python/testRunCmdLine.py
@@ -31,11 +31,19 @@ class RunModuleFromCmdLineTest(RunCmdLineBaseTest):
         return ['-m', "modules.A"]
 
     def test_can_run_module_from_cmdline(self):
-        self.smvApp.j_smvApp.run()
+        self.smvApp.run()
         a = self.df("runstage.stage1.modules.A")
         expected = self.createDF("k:String;v:Integer", "a,;b,2")
         self.should_be_same(a, expected)
 
+class DryRunTest(RunCmdLineBaseTest):
+    @classmethod
+    def whatToRun(cls):
+        return ["-m", "modules.A", "--dry-run"]
+
+    def test_dry_run_just_print(self):
+        self.smvApp.run()
+        self.assertFalse(self.load("runstage.stage1.modules.A")[0].isPersisted())
 
 class RunStageFromCmdLineTest(RunCmdLineBaseTest):
     @classmethod
@@ -43,7 +51,7 @@ class RunStageFromCmdLineTest(RunCmdLineBaseTest):
         return ['-s', "runstage.stage1"]
 
     def test_can_run_stage_from_cmdline(self):
-        self.smvApp.j_smvApp.run()
+        self.smvApp.run()
         a = self.df("runstage.stage1.modules.A")
         self.should_be_same(a, self.createDF("k:String;v:Integer", "a,;b,2"))
         b = self.df("runstage.stage1.modules.B")


### PR DESCRIPTION
Fixed #1370 

This is the last step of #1370.

Since we will not change behaviors of this issue, we still leave some of the functions for handling command line on Scala side. Since we moved the run method itself to Python, we can than move those functions one by one with the behavior changes needed for them as in separated issues.