### PR TITLE
I1384 step1 smvconf on python

### DIFF
--- a/docs/user/run_app.md
+++ b/docs/user/run_app.md
@@ -66,17 +66,6 @@ When enabled, all persisted modules will have a corresponding EDD file that show
 </tr>
 
 <tr>
-<td>--edd-compare</td>
-<td>None</td>
-<td>compare the two given edd results (results of two previous --edd runs)
-<br>
-User must supply two edd files to compare
-<br>
-<code>$ ... --edd-compare /data/output/v1/foo.edd /data/output/v2/foo.edd</code>
-</td>
-</tr>
-
-<tr>
 <td>--graph / -g</td>
 <td>off</td>
 <td>Generate a dependency graph ".dot" file instead of running the given modules.<br>

--- a/src/main/python/smv/datasetmgr.py
+++ b/src/main/python/smv/datasetmgr.py
@@ -75,3 +75,11 @@ class DataSetMgr(object):
         """
         j_dss = self.j_dsm.allDataSets()
         return scala_seq_to_list(self._jvm, j_dss)
+
+    def modulesToRun(self, modPartialNames, stageNames, allMods):
+        return self.helper.dsmModulesToRun(
+            self.j_dsm,
+            smv_copy_array(self.sc, *modPartialNames), 
+            smv_copy_array(self.sc, *stageNames), 
+            allMods
+        )

--- a/src/main/python/smv/jprops.py
+++ b/src/main/python/smv/jprops.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2011-2015, Matt Good <matt@matt-good.net>
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Copied from https://github.com/mgood/jprops
+
+import io
+import re
+import string
+import sys
+import time
+
+
+PY2 = sys.version_info[0] == 2
+if not PY2:
+  text_type = str
+  string_types = (str,)
+  unichr = chr
+else:
+  text_type = unicode
+  string_types = (str, unicode)
+  unichr = unichr
+
+
+class _CommentSentinel(object):
+  __slots__ = ()
+  def __repr__(self):
+    return 'jprops.COMMENT'
+  def __copy__(self):
+    return self
+  def __deepcopy__(self, memo):
+    return self
+  def __reduce__(self):
+    return 'COMMENT'
+
+
+COMMENT = _CommentSentinel()
+
+
+def load_properties(fh, mapping=dict):
+  """
+    Reads properties from a Java .properties file.
+
+    Returns a dict (or provided mapping) of properties.
+
+    :param fh: a readable file-like object
+    :param mapping: mapping type to load properties into
+  """
+  return mapping(iter_properties(fh))
+
+
+def store_properties(fh, props, comment=None, timestamp=True):
+  """
+    Writes properties to the file in Java properties format.
+
+    :param fh: a writable file-like object
+    :param props: a mapping (dict) or iterable of key/value pairs
+    :param comment: comment to write to the beginning of the file
+    :param timestamp: boolean indicating whether to write a timestamp comment
+  """
+  w = _property_writer(fh)
+
+  if comment is not None:
+    w.write_comment(comment)
+
+  if timestamp:
+    w.write_comment(time.strftime('%a %b %d %H:%M:%S %Z %Y'))
+
+  if hasattr(props, 'keys'):
+    for key in props:
+      w.write_property(key, props[key])
+  else:
+    for key, value in props:
+      w.write_property(key, value)
+
+
+def write_comment(fh, comment):
+  """
+    Writes a comment to the file in Java properties format.
+
+    Newlines in the comment text are automatically turned into a continuation
+    of the comment by adding a "#" to the beginning of each line.
+
+    :param fh: a writable file-like object
+    :param comment: comment string to write
+  """
+  _property_writer(fh).write_comment(comment)
+
+
+def write_property(fh, key, value):
+  """
+    Write a single property to the file in Java properties format.
+
+    :param fh: a writable file-like object
+    :param key: the key to write
+    :param value: the value to write
+  """
+  _property_writer(fh).write_property(key, value)
+
+
+def iter_properties(fh, comments=False):
+  """
+    Incrementally read properties from a Java .properties file.
+
+    Yields tuples of key/value pairs.
+
+    If ``comments`` is `True`, comments will be included with ``jprops.COMMENT``
+    in place of the key.
+
+    :param fh: a readable file-like object
+    :param comments: should include comments (default: False)
+  """
+  for line in _property_lines(fh):
+    key, value = _split_key_value(line)
+    if key is not COMMENT:
+      key = _unescape(key)
+    elif not comments:
+      continue
+    yield key, _unescape(value)
+
+
+################################################################################
+# Helpers for property parsing/writing
+################################################################################
+
+
+_COMMENT_CHARS = u'#!'
+_LINE_PATTERN = re.compile(r'^\s*(?P<body>.*?)(?P<backslashes>\\*)$')
+_KEY_TERMINATORS_EXPLICIT = u'=:'
+_KEY_TERMINATORS = _KEY_TERMINATORS_EXPLICIT + string.whitespace
+_COMMENT_UNICODE_ESCAPE = re.compile(u'[\u0100-\uffff]')
+_PROPERTY_UNICODE_ESCAPE = re.compile(u'[\u0000-\u0019\u007f-\uffff]')
+
+
+_escapes = {
+  't': '\t',
+  'n': '\n',
+  'f': '\f',
+  'r': '\r',
+}
+_escapes_rev = dict((v, '\\' + k) for k,v in _escapes.items())
+for c in '\\' + _COMMENT_CHARS + _KEY_TERMINATORS_EXPLICIT:
+  _escapes_rev.setdefault(c, '\\' + c)
+
+
+def _unescape(value):
+  def unirepl(m):
+    backslashes = m.group(1)
+    charcode = m.group(2)
+
+    # if preceded by even number of backslashes, the \u is escaped
+    if len(backslashes) % 2 == 0:
+      return m.group(0)
+
+    c = unichr(int(charcode, 16))
+    # if unicode decodes to '\', re-escape it to unescape in the second step
+    if c == '\\':
+      c = u'\\\\'
+
+    return backslashes + c
+
+  value = re.sub(r'(\\+)u([0-9a-fA-F]{4})', unirepl, value)
+
+  def bslashrepl(m):
+    code = m.group(1)
+    return _escapes.get(code, code)
+
+  value = re.sub(r'\\(.)', bslashrepl, value)
+
+  # if not native string (e.g. PY2) try converting it back
+  if not isinstance(value, str):
+    try:
+      value = value.encode('ascii')
+    except UnicodeEncodeError:
+      # cannot be represented in ASCII so leave it as unicode type
+      pass
+
+  return value
+
+
+def _escape_comment(comment):
+  comment = comment.replace('\r\n', '\n').replace('\r', '\n')
+  comment = re.sub(r'\n(?![#!])', '\n#', comment)
+  return u'#' + comment
+
+
+def _escape_key(key):
+  return _escape(key, _KEY_TERMINATORS)
+
+
+def _escape_value(value):
+  tail = value.lstrip()
+  if len(tail) == len(value):
+    return _escape(value)
+
+  if tail:
+    head = value[:-len(tail)]
+  else:
+    head = value
+
+  # escape any leading whitespace, but leave other spaces intact
+  return _escape(head, string.whitespace) + _escape(tail)
+
+
+def _escape(value, chars=''):
+  escape_chars = set(_escapes_rev)
+  escape_chars.update(chars)
+  escape_pattern = '[%s]' % re.escape(''.join(escape_chars))
+
+  def esc(m):
+    c = m.group(0)
+    return _escapes_rev.get(c) or '\\' + c
+  value = re.sub(escape_pattern, esc, value)
+
+  return value
+
+
+def _unicode_replace(m):
+  c = m.group(0)
+  return r'\u%.4x' % ord(c)
+
+
+def _split_key_value(line):
+  if line[0] in _COMMENT_CHARS:
+    return COMMENT, line[1:]
+
+  escaped = False
+  key_buf = io.StringIO()
+
+  for idx, c in enumerate(line):
+    if not escaped and c in _KEY_TERMINATORS:
+      key_terminated_fully = c in _KEY_TERMINATORS_EXPLICIT
+      break
+
+    key_buf.write(c)
+    escaped = c == u'\\'
+
+  else:
+    # no key terminator, key is full line & value is blank
+    return line, u''
+
+  value = line[idx+1:].lstrip()
+  if not key_terminated_fully and value[:1] in _KEY_TERMINATORS_EXPLICIT:
+    value = value[1:].lstrip()
+
+  return key_buf.getvalue(), value
+
+
+def _is_text_file(fp):
+  return (
+    isinstance(fp, io.TextIOBase)
+    or getattr(fp, 'encoding', None) is not None
+  )
+
+
+def _read_lines(fp):
+  lines = iter(fp)
+  if not _is_text_file(fp):
+    lines = (line.decode('latin-1') for line in lines)
+
+  # if file was not opened with universal newline support convert the newlines
+  if 'U' not in getattr(fp, 'mode', ''):
+    lines = _universal_newlines(lines)
+
+  return lines
+
+
+def _universal_newlines(lines):
+  for line in lines:
+    line = line.replace('\r\n', '\n').replace('\r', '\n')
+    for piece in line.split('\n'):
+      yield piece
+
+
+def _property_lines(fp):
+  buf = io.StringIO()
+  for line in _read_lines(fp):
+    m = _LINE_PATTERN.match(line)
+
+    body = m.group('body')
+    backslashes = m.group('backslashes')
+
+    if len(backslashes) % 2 == 0:
+      body += backslashes
+      continuation = False
+    else:
+      body += backslashes[:-1]
+      continuation = True
+
+    if not body:
+      continue
+
+    buf.write(body)
+
+    if not continuation:
+      yield buf.getvalue()
+      buf = io.StringIO()
+
+
+def _property_writer(fh):
+  if _is_text_file(fh):
+    return _TextPropertyWriter(fh)
+  else:
+    return _BytesPropertyWriter(fh)
+
+
+def _require_string(value, name):
+  if isinstance(value, text_type):
+    return value
+
+  if isinstance(value, string_types):
+    # allow Python 2 native strings
+    return value.decode('latin-1')
+
+  valid_types = ' or '.join(cls.__name__ for cls in string_types)
+  raise TypeError('%s must be %s, but got: %s %r'
+                  % (name, valid_types, type(value), value))
+
+
+class _TextPropertyWriter(object):
+  _escape_comment = staticmethod(_escape_comment)
+  _escape_key = staticmethod(_escape_key)
+  _escape_value = staticmethod(_escape_value)
+
+  def __init__(self, fp):
+    self.fp = fp
+
+  def write_property(self, key, value):
+    if key is COMMENT:
+      self.write_comment(value)
+      return
+
+    key = _require_string(key, 'keys')
+    value = _require_string(value, 'values')
+
+    key = self._escape_key(key)
+    value = self._escape_value(value)
+
+    self._write(key)
+    self._write(u'=')
+    self._write(value)
+    self._write(u'\n')
+
+  def write_comment(self, comment):
+    comment = _require_string(comment, 'comments')
+    comment = self._escape_comment(comment)
+    self._write(comment)
+    self._write(u'\n')
+
+  def _write(self, data):
+    self.fp.write(data)
+
+
+class _BytesPropertyWriter(_TextPropertyWriter):
+  def _write(self, data):
+    self.fp.write(data.encode('latin-1'))
+
+  def _escape_comment(self, comment):
+    comment = _TextPropertyWriter._escape_comment(comment)
+    return _COMMENT_UNICODE_ESCAPE.sub(_unicode_replace, comment)
+
+  def _escape_key(self, key):
+    key = _TextPropertyWriter._escape_key(key)
+    return _PROPERTY_UNICODE_ESCAPE.sub(_unicode_replace, key)
+
+  def _escape_value(self, value):
+    value = _TextPropertyWriter._escape_value(value)
+    return _PROPERTY_UNICODE_ESCAPE.sub(_unicode_replace, value)

--- a/src/main/python/smv/jprops.py
+++ b/src/main/python/smv/jprops.py
@@ -23,6 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Copied from https://github.com/mgood/jprops
+# For java properties file loading
 
 import io
 import re

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -506,9 +506,6 @@ class SmvApp(object):
         cl = self.py_smvconf.cmdline
         return namedtuple("CmdLine", cl.keys())(*cl.values())
         
-    def _modules_to_run(self):
-        return scala_seq_to_list(self._jvm, self.j_smvApp.modulesToRun())
-
     def _dry_run(self):
         """Execute as dry-run if the dry-run flag is specified.
             This will show which modules are not yet persisted that need to run, without
@@ -552,6 +549,12 @@ class SmvApp(object):
             return True
         else:
             return False
+
+    def _modules_to_run(self):
+        modPartialNames = self.py_smvconf.mods_to_run
+        stageNames      = [self.py_smvconf.inferStageFullName(f) for f in self.py_smvconf.stages_to_run]
+
+        return self.dsm.modulesToRun(modPartialNames, stageNames, self._cmd_line().runAllApp)
 
     def run(self):
         self.j_smvApp.purgeCurrentOutputFiles()

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -565,7 +565,6 @@ class SmvApp(object):
         #either generate graphs, publish modules, or run output modules (only one will occur)
         self._print_dead_modules() \
         or self._dry_run() \
-        or self.j_smvApp.compareEddResults() \
         or self._generate_dot_graph() \
         or self.j_smvApp.publishModulesToHive(collector) \
         or self.j_smvApp.publishOutputModules(collector) \

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -13,49 +13,130 @@
 """
 Handle command line args and props files
 """
+import os.path
 import argparse
+import uuid
+import smv.jprops as jprops
 
-def create_cmdline_conf(arglist):
-    """Parse arglist to a config dictionary"""
-    parser = argparse.ArgumentParser(
-        usage="smv-run -m ModuleToRun\n       smv-run --run-app",
-        description="For additional usage information, please refer to the user guide and API docs at: \nhttp://tresamigossd.github.io/SMV"
-    )
+class SmvConfig(object):
+    def __init__(self, arglist):
+        self.cmdline = self._create_cmdline_conf(arglist)
+        self.run_app_flags = _run_app_flags
+        
+        DEFAULT_SMV_HOME_CONF_FILE = os.getenv('HOME', '') + "/.smv/smv-user-conf.props"
 
-    DEFAULT_SMV_APP_CONF_FILE  = "conf/smv-app-conf.props"
-    DEFAULT_SMV_USER_CONF_FILE = "conf/smv-user-conf.props"
-  
-    parser.add_argument('--smv-app-dir', dest='smvAppDir', default=".", help="SMV app directory")
-    parser.add_argument('--cbs-port', dest='cbsPort', type=int, help="python callback server port")
-    parser.add_argument('--smv-app-conf', dest='smvAppConfFile', default=DEFAULT_SMV_APP_CONF_FILE, help="app level (static) SMV configuration file path")
-    parser.add_argument('--smv-user-conf', dest='smvUserConfFile', default=DEFAULT_SMV_USER_CONF_FILE, help="user level (dynamic) SMV configuration file path")
-    parser.add_argument('--publish', dest='publish', help="publish the given modules/stage/app as given version")
-    parser.add_argument('--export-csv', dest='exportCsv', help="publish|export given modules/stage/app to a CSV file at the given path on the local file system")
+        self.app_dir = self.cmdline.pop('smvAppDir')
+        self.static_props = {}
+        self.dynamic_props = {}
 
-    parser.add_argument('--force-run-all', dest='forceRunAll', action="store_true", help="ignore persisted data and force all modules to run")
-    parser.add_argument('--publish-jdbc', dest='publishJDBC', action="store_true", help="publish the given modules/stage/app through JDBC connection")
-    parser.add_argument('--publish-hive', dest='publishHive', action="store_true", help="publish|export given modules/stage/app to hive tables")
-    parser.add_argument('--dead', dest='printDeadModules', action="store_true", help="print a list of the dead modules in this application")
-    parser.add_argument('--graph', dest='graph', action="store_true", help="generate a dot dependency graph of the given modules (modules are not run)")
-    parser.add_argument('--purge-old-output', dest='purgeOldOutput', action="store_true", help="remove all old output files in output dir")
-    parser.add_argument('--dry-run', dest='dryRun', action="store_true", help="determine which modules do not have persisted data and will need to be run")
+        self.app_conf_path = self.cmdline.pop('smvAppConfFile')
+        self.home_conf_path = DEFAULT_SMV_HOME_CONF_FILE
+        self.user_conf_path = self.cmdline.pop('smvUserConfFile')
+        self.cmdline_props = dict(self.cmdline.pop('smvProps'))
 
-    parser.add_argument('--data-dir', dest='dataDir', help="specify the top level data directory")
-    parser.add_argument('--input-dir', dest='inputDir', help="specify the input directory (default: datadir/input)")
-    parser.add_argument('--output-dir', dest='outputDir', help="specify the output directory (default: datadir/output)")
-    parser.add_argument('--hostory-dir', dest='historyDir', help="specify the history directory (default: datadir/history)")
-    parser.add_argument('--publish-dir', dest='publishDir', help="specify the publish directory (default: datadir/publish)")
+        self.read_props_from_app_dir(self.cmdline['smvAppDir'])
 
-    parser.add_argument('--run-app', dest='runAllApp', action='store_true', help="run all output modules in all stages in app")
-    parser.add_argument('-m', '--run-module', dest='modsToRun', nargs='+', help="run specified list of module FQNs")
-    parser.add_argument('-s', '--run-stage', dest='stagesToRun', nargs='+', help="run all output modules in specified stages")
+    def read_props_from_app_dir(self, _app_dir):
+        self.app_dir = _app_dir
+        self.static_props = self._read_props()
 
-    def parse_props(prop):
-        return prop.split("=")
+    def merged_props(self):
+        res = self.static_props.copy()
+        res.update(self.dynamic_props)
+        return res
 
-    parser.add_argument('--smv-props', dest="smvProps", nargs='+', type=parse_props, help="key=value command line props override")
+    def print_conf(self):
+        print(self.cmdline)
+        print(self.merged_props())
 
-    res = vars(parser.parse_args(arglist))
-    res.update({'smvProps': dict(res['smvProps'])})
+    def _create_cmdline_conf(self):
+        """Parse arglist to a config dictionary"""
+        parser = argparse.ArgumentParser(
+            usage="smv-run -m ModuleToRun\n       smv-run --run-app",
+            description="For additional usage information, please refer to the user guide and API docs at: \nhttp://tresamigossd.github.io/SMV"
+        )
 
-    return res
+        DEFAULT_SMV_APP_CONF_FILE  = "conf/smv-app-conf.props"
+        DEFAULT_SMV_USER_CONF_FILE = "conf/smv-user-conf.props"
+    
+        parser.add_argument('--cbs-port', dest='cbsPort', type=int, help="python callback server port")
+
+        # Where to find props files
+        parser.add_argument('--smv-app-dir', dest='smvAppDir', default=".", help="SMV app directory")
+        parser.add_argument('--smv-app-conf', dest='smvAppConfFile', default=DEFAULT_SMV_APP_CONF_FILE, help="app level (static) SMV configuration file path")
+        parser.add_argument('--smv-user-conf', dest='smvUserConfFile', default=DEFAULT_SMV_USER_CONF_FILE, help="user level (dynamic) SMV configuration file path")
+
+        # Where to find/store data
+        parser.add_argument('--data-dir', dest='dataDir', help="specify the top level data directory")
+        parser.add_argument('--input-dir', dest='inputDir', help="specify the input directory (default: datadir/input)")
+        parser.add_argument('--output-dir', dest='outputDir', help="specify the output directory (default: datadir/output)")
+        parser.add_argument('--hostory-dir', dest='historyDir', help="specify the history directory (default: datadir/history)")
+        parser.add_argument('--publish-dir', dest='publishDir', help="specify the publish directory (default: datadir/publish)")
+
+        # All app run flags
+        parser.add_argument('--force-run-all', dest='forceRunAll', action="store_true", help="ignore persisted data and force all modules to run")
+        parser.add_argument('--publish-jdbc', dest='publishJDBC', action="store_true", help="publish the given modules/stage/app through JDBC connection")
+        parser.add_argument('--publish-hive', dest='publishHive', action="store_true", help="publish|export given modules/stage/app to hive tables")
+        parser.add_argument('--dead', dest='printDeadModules', action="store_true", help="print a list of the dead modules in this application")
+        parser.add_argument('--graph', dest='graph', action="store_true", help="generate a dot dependency graph of the given modules (modules are not run)")
+        parser.add_argument('--purge-old-output', dest='purgeOldOutput', action="store_true", help="remove all old output files in output dir")
+        parser.add_argument('--dry-run', dest='dryRun', action="store_true", help="determine which modules do not have persisted data and will need to be run")
+
+        # Where to output CSVs
+        parser.add_argument('--publish', dest='publish', help="publish the given modules/stage/app as given version")
+        parser.add_argument('--export-csv', dest='exportCsv', help="publish|export given modules/stage/app to a CSV file at the given path on the local file system")
+
+        # What modules to run
+        parser.add_argument('--run-app', dest='runAllApp', action='store_true', help="run all output modules in all stages in app")
+        parser.add_argument('-m', '--run-module', dest='modsToRun', nargs='+', help="run specified list of module FQNs")
+        parser.add_argument('-s', '--run-stage', dest='stagesToRun', nargs='+', help="run all output modules in specified stages")
+
+        def parse_props(prop):
+            return prop.split("=")
+
+        # command line props override
+        parser.add_argument('--smv-props', dest="smvProps", nargs='+', type=parse_props, default=[], help="key=value command line props override")
+
+        res = vars(parser.parse_args(self.arglist))
+        app_run_flag_keys = [
+            'forceRunAll', 'publishJDBC', 'publishHive', 'printDeadModules', 'graph', 'purgeOldOutput', 'dryRun', 
+            'publish', 'exportCsv',
+            'runAllApp', 'modsToRun', 'stagesToRun'
+        ]
+        app_run_flags = {k: res[k] for k in app_run_flag_keys}
+        return res
+
+
+    def _read_props(self):
+        # os.path.join has the following behavior:
+        # ("/a/b", "c/d") -> "/a/b/c/d"
+        # ("/a/b", "/c/d") -> "/c/d"
+        full_app_conf_path = os.path.join(self.app_dir, self.app_conf_path)
+        full_user_conf_path = os.path.join(self.app_dir, self.user_conf_path)
+
+        with open(full_app_conf_path) as fp:
+            app_conf_props = jprops.load_properties(fp)
+
+        with open(self.home_conf_path) as fp:
+            home_conf_props = jprops.load_properties(fp)
+    
+        with open(full_user_conf_path) as fp:
+            user_conf_props = jprops.load_properties(fp)
+
+        default_props = {
+            "smv.appName"            : "Smv Application",
+            "smv.appId"              : str(uuid.uuid4())
+            "smv.stages"             : "",
+            "smv.config.keys"        : "",
+            "smv.class_dir"          : "./target/classes",
+            "smv.user_libraries"     : "",
+            "smv.maxCbsPortRetries"  : "10"
+        }
+
+        res = {}
+        res.update(default_props)
+        res.update(app_conf_props)
+        res.update(home_conf_props)
+        res.update(user_conf_props)
+        res.update(self.cmdline_props)
+        return res

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -163,6 +163,7 @@ class SmvConfig(object):
         parser.add_argument('--graph', dest='graph', action="store_true", help="generate a dot dependency graph of the given modules (modules are not run)")
         parser.add_argument('--purge-old-output', dest='purgeOldOutput', action="store_true", help="remove all old output files in output dir")
         parser.add_argument('--dry-run', dest='dryRun', action="store_true", help="determine which modules do not have persisted data and will need to be run")
+        parser.add_argument('--edd', dest='genEdd', action="store_true", help="summarize data and generate an edd file in the same directory as csv and schema")
 
         # Where to output CSVs
         parser.add_argument('--publish', dest='publish', help="publish the given modules/stage/app as given version")

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -111,7 +111,7 @@ class SmvConfig(object):
     def stage_names(self):
         return self._split_prop("smv.stages")
 
-    def infer_full_stage_name(self, part_name):
+    def infer_stage_full_name(self, part_name):
         all_stages = self.stage_names()
         candidates = [s for s in all_stages if s.endswith(part_name)]
 
@@ -175,7 +175,8 @@ class SmvConfig(object):
         parser.add_argument('-s', '--run-stage', dest='stagesToRun', nargs='+', default=[], help="run all output modules in specified stages")
 
         def parse_props(prop):
-            return prop.split("=")
+            # str.split([sep[, maxsplit]]): we just need to split the first "="
+            return prop.split("=", 1) 
 
         # command line props override
         parser.add_argument('--smv-props', dest="smvProps", nargs='+', type=parse_props, default=[], help="key=value command line props override")

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -1,0 +1,61 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Handle command line args and props files
+"""
+import argparse
+
+def create_cmdline_conf(arglist):
+    """Parse arglist to a config dictionary"""
+    parser = argparse.ArgumentParser(
+        usage="smv-run -m ModuleToRun\n       smv-run --run-app",
+        description="For additional usage information, please refer to the user guide and API docs at: \nhttp://tresamigossd.github.io/SMV"
+    )
+
+    DEFAULT_SMV_APP_CONF_FILE  = "conf/smv-app-conf.props"
+    DEFAULT_SMV_USER_CONF_FILE = "conf/smv-user-conf.props"
+  
+    parser.add_argument('--smv-app-dir', dest='smvAppDir', default=".", help="SMV app directory")
+    parser.add_argument('--cbs-port', dest='cbsPort', type=int, help="python callback server port")
+    parser.add_argument('--smv-app-conf', dest='smvAppConfFile', default=DEFAULT_SMV_APP_CONF_FILE, help="app level (static) SMV configuration file path")
+    parser.add_argument('--smv-user-conf', dest='smvUserConfFile', default=DEFAULT_SMV_USER_CONF_FILE, help="user level (dynamic) SMV configuration file path")
+    parser.add_argument('--publish', dest='publish', help="publish the given modules/stage/app as given version")
+    parser.add_argument('--export-csv', dest='exportCsv', help="publish|export given modules/stage/app to a CSV file at the given path on the local file system")
+
+    parser.add_argument('--force-run-all', dest='forceRunAll', action="store_true", help="ignore persisted data and force all modules to run")
+    parser.add_argument('--publish-jdbc', dest='publishJDBC', action="store_true", help="publish the given modules/stage/app through JDBC connection")
+    parser.add_argument('--publish-hive', dest='publishHive', action="store_true", help="publish|export given modules/stage/app to hive tables")
+    parser.add_argument('--dead', dest='printDeadModules', action="store_true", help="print a list of the dead modules in this application")
+    parser.add_argument('--graph', dest='graph', action="store_true", help="generate a dot dependency graph of the given modules (modules are not run)")
+    parser.add_argument('--purge-old-output', dest='purgeOldOutput', action="store_true", help="remove all old output files in output dir")
+    parser.add_argument('--dry-run', dest='dryRun', action="store_true", help="determine which modules do not have persisted data and will need to be run")
+
+    parser.add_argument('--data-dir', dest='dataDir', help="specify the top level data directory")
+    parser.add_argument('--input-dir', dest='inputDir', help="specify the input directory (default: datadir/input)")
+    parser.add_argument('--output-dir', dest='outputDir', help="specify the output directory (default: datadir/output)")
+    parser.add_argument('--hostory-dir', dest='historyDir', help="specify the history directory (default: datadir/history)")
+    parser.add_argument('--publish-dir', dest='publishDir', help="specify the publish directory (default: datadir/publish)")
+
+    parser.add_argument('--run-app', dest='runAllApp', action='store_true', help="run all output modules in all stages in app")
+    parser.add_argument('-m', '--run-module', dest='modsToRun', nargs='+', help="run specified list of module FQNs")
+    parser.add_argument('-s', '--run-stage', dest='stagesToRun', nargs='+', help="run all output modules in specified stages")
+
+    def parse_props(prop):
+        return prop.split("=")
+
+    parser.add_argument('--smv-props', dest="smvProps", nargs='+', type=parse_props, help="key=value command line props override")
+
+    res = vars(parser.parse_args(arglist))
+    res.update({'smvProps': dict(res['smvProps'])})
+
+    return res

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -112,27 +112,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
     dsList foreach (ds => ds.deleteOutputs(ds.versionedOutputFiles))
 
   /**
-   * compare EDD results if the --edd-compare flag was specified with edd files to compare.
-   * @return true if edd files were compared, otherwise false.
-   */
-  private[smv] def compareEddResults(): Boolean = {
-    smvConfig.cmdLine.compareEdd
-      .map { eddsToCompare =>
-        val edd1          = eddsToCompare(0)
-        val edd2          = eddsToCompare(1)
-        val (passed, log) = util.Edd.compareFiles(edd1, edd2)
-        if (passed) {
-          println("EDD Results are the same")
-        } else {
-          println("EDD Results differ:")
-          println(log)
-        }
-        true
-      }
-      .orElse(Some(false))()
-  }
-
-  /**
    * if the publish to hive flag is setn, the publish
    */
   def publishModulesToHive(collector: SmvRunInfoCollector): Boolean = {

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -84,10 +84,6 @@ private[smv] class CmdLineArgsConf(args: Seq[String]) extends ScallopConf(args) 
     descr = "publish|export given modules/stage/app to a CSV file at the given path on the local file system"
   )
 
-  val compareEdd = opt[List[String]]("edd-compare",
-                                     noshort = true,
-                                     default = None,
-                                     descr = "compare two edd result files")
   val genEdd = toggle(
     "edd",
     default = Some(false),
@@ -144,12 +140,6 @@ private[smv] class CmdLineArgsConf(args: Seq[String]) extends ScallopConf(args) 
                       noshort = true,
                       default = Some(false),
                       descrYes = "determine which modules do not have persisted data and will need to be run.")
-
-  // if user specified "edd-compare" command line, user should have supplied two file names.
-  validateOpt(compareEdd) {
-    case (Some(edds)) if edds.length != 2 => Left("edd-compare param requires two EDD file names")
-    case _                                => Right(Unit)
-  }
 
   // override default error message handler that does a sys.exit(1) which makes it difficult to debug.
   printedName = "SmvApp"

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -17,7 +17,7 @@ package org.tresamigos.smv
 import scala.util.Try
 
 import java.io.{IOException, InputStreamReader, FileInputStream, File}
-import java.util.Properties
+import java.util.{Properties, ArrayList}
 
 import org.rogach.scallop.ScallopConf
 
@@ -349,5 +349,29 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
     mergedProps.get(propName).flatMap { s: String =>
       Try(s.toInt).toOption
     }
+  }
+}
+
+class SmvConfig2(
+  val modsToRun: ArrayList[String],
+  val stagesToRun: ArrayList[String],
+  val cmdLine: java.util.Map[String, String],
+  var props: java.util.Map[String, String],
+  var dataDirs: java.util.Map[String, String]
+){
+  def printall() = {
+    println(modsToRun)
+    println(stagesToRun)
+    println(cmdLine)
+    println(props)
+    println(dataDirs)
+  }
+
+  def reset(
+    _props: java.util.Map[String, String], 
+    _dataDirs: java.util.Map[String, String]
+  ) {
+    props = _props
+    dataDirs = _dataDirs
   }
 }

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -108,11 +108,6 @@ private[smv] class CmdLineArgsConf(args: Seq[String]) extends ScallopConf(args) 
     descrNo = "do not generate a json dependency graph"
   )
 
-  val runConfObj = opt[String]("run-conf-obj",
-                               noshort = true,
-                               default = None,
-                               descr = "load and instantiate the configuration object by its fqn")
-
   // --- data directories override
   val dataDir =
     opt[String]("data-dir", noshort = true, descr = "specify the top level data directory")
@@ -170,7 +165,6 @@ private[smv] class CmdLineArgsConf(args: Seq[String]) extends ScallopConf(args) 
  */
 class SmvConfig(cmdLineArgs: Seq[String]) {
   import java.nio.file.Paths
-  import SmvConfig._
 
   /*pathJoin has the following behavior:
    *pathJoin("/a/b", "c/d") -> "/a/b/c/d"
@@ -242,8 +236,6 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
   // --- user libraries are dynamic as well
   private[smv] def userLibs = { splitProp("smv.user_libraries").toSeq }
 
-  val classDir = mergedProps("smv.class_dir")
-
   val sparkSqlProps = mergedProps.filterKeys(k => k.startsWith("spark.sql."))
 
   def jdbcUrl: String =
@@ -258,9 +250,6 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
     case None => throw new SmvRuntimeException("JDBC driver is not specified in SMV config")
     case Some(ret) => ret
   }
-
-  /** The FQN of configuration object for a particular run.  See github issue #319 */
-  val runConfObj: Option[String] = cmdLine.runConfObj.get.orElse(mergedProps.get(RunConfObjKey))
 
   // ---------- User Run Config Parameters key/values ----------
   def getRunConfig(key: String): String = dynamicRunConfig.getOrElse(key, getRunConfigFromConf(key))
@@ -361,8 +350,4 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
       Try(s.toInt).toOption
     }
   }
-}
-
-object SmvConfig {
-  val RunConfObjKey: String = "smv.runConfObj"
 }

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -342,6 +342,9 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
   }
 }
 
+/** Scaffolding: for python side to test passing in configs.
+ *  Target interface for future SmvConfig class
+ **/
 class SmvConfig2(
   val modsToRun: ArrayList[String],
   val stagesToRun: ArrayList[String],

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -200,6 +200,9 @@ object SmvPythonHelper {
 
   def dsmDataSetsForStage(dsm: DataSetMgr, stage: String): java.util.List[SmvDataSet] = 
     dsm.dataSetsForStage(stage)
+
+  def dsmModulesToRun(dsm: DataSetMgr, modPartialNames: Array[String], stageNames: Array[String], allMods: Boolean): java.util.List[SmvDataSet] =
+    dsm.modulesToRun(modPartialNames, stageNames, allMods)
 }
 
 class SmvGroupedDataAdaptor(grouped: SmvGroupedData) {

--- a/src/test/scala/org/tresamigos/smv/SmvConfigTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvConfigTest.scala
@@ -102,12 +102,6 @@ package org.tresamigos.smv {
       assertUnorderedSeqEqual(ss, Seq("com.myproj.s1pkg", "com.myproj.s2pkg"))
     }
 
-    test("test EDD args") {
-      val conf = mkconfig("--edd", "--edd-compare", "/tmp/file1.edd", "/tmp/file2.edd")
-      assert(conf.cmdLine.genEdd() === true)
-      assert(conf.cmdLine.compareEdd() === List("/tmp/file1.edd", "/tmp/file2.edd"))
-    }
-
     test("test input/output/data dir command line override") {
       import java.io.File
       val conf = mkconfig("--smv-props",

--- a/src/test/scala/org/tresamigos/smv/SmvConfigTest.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvConfigTest.scala
@@ -102,6 +102,11 @@ package org.tresamigos.smv {
       assertUnorderedSeqEqual(ss, Seq("com.myproj.s1pkg", "com.myproj.s2pkg"))
     }
 
+    test("test EDD args") {
+      val conf = mkconfig("--edd")
+      assert(conf.cmdLine.genEdd() === true)
+    }
+  
     test("test input/output/data dir command line override") {
       import java.io.File
       val conf = mkconfig("--smv-props",


### PR DESCRIPTION
Step 1 of #1384 

- Created python side SmvConfig class to
    - parse command line
    - load properties from files
    - prepared for dynamic conf (not implemented yet)
    - send parsed command line and props to a dummy scala SmvConfig2 class
- Implement python side SmvApp run method's action methods using python side cmdline
- Removed edd compare command line option