### PR TITLE
I1384 step2 scala smvconf clean

### DIFF
--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -193,14 +193,17 @@ class SmvApp(object):
         dds = self.py_smvconf.all_data_dirs()
         return namedtuple("DataDirs", dds.keys())(*dds.values())
 
-    def config(self):
-        return self.j_smvApp.smvConfig()
-
     def appName(self):
         return self.py_smvconf.app_name()
 
+    def appDir(self):
+        return self.py_smvconf.app_dir
+
     def maxCbsPortRetries(self):
-        return self.py_smvconf.merged_props.get('smv.maxCbsPortRetries')
+        return self.py_smvconf.merged_props().get('smv.maxCbsPortRetries')
+
+    def jdbcUrl(self):
+        return self.py_smvconf.merged_props().get('smv.jdbc.url')
 
     def getConf(self, key):
         return self.j_smvPyClient.getRunConfig(key)
@@ -491,8 +494,7 @@ class SmvApp(object):
 
     def abs_path_for_project_path(self, project_path):
         # Load dynamic app dir from scala
-        smvAppDir = self.py_smvconf.app_dir
-        return os.path.abspath(os.path.join(smvAppDir, project_path))
+        return os.path.abspath(os.path.join(self.appDir(), project_path))
 
     def prepend_source(self, project_path):
         abs_path = self.abs_path_for_project_path(project_path)

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -212,6 +212,7 @@ class SmvApp(object):
         # this call sets the scala side's picture of app dir and forces
         # the app properties to be read from disk and reevaluated
         self.j_smvPyClient.setAppDir(appDir)
+        self.py_smvconf.set_app_dir(appDir)
 
         # this call will use the dynamic appDir that we just set ^
         # to change sys.path, allowing py modules, UDL's to be discovered by python
@@ -219,6 +220,7 @@ class SmvApp(object):
 
     def setDynamicRunConfig(self, runConfig):
         self.j_smvPyClient.setDynamicRunConfig(runConfig)
+        self.py_smvconf.set_dynamic_props(runConfig)
 
     def getCurrentProperties(self, raw = False):
         """ Python dict of current megred props

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -197,10 +197,10 @@ class SmvApp(object):
         return self.j_smvApp.smvConfig()
 
     def appName(self):
-        return self.config().appName()
+        return self.py_smvconf.app_name()
 
     def maxCbsPortRetries(self):
-        return self.config().maxCbsPortRetries()
+        return self.py_smvconf.merged_props.get('smv.maxCbsPortRetries')
 
     def getConf(self, key):
         return self.j_smvPyClient.getRunConfig(key)
@@ -236,10 +236,10 @@ class SmvApp(object):
 
     def userLibs(self):
         """Return dynamically set smv.user_libraries from conf"""
-        return self.j_smvPyClient.userLibs()
+        return self.py_smvconf.user_libs()
 
     def appId(self):
-        return self.config().appId()
+        return self.py_smvconf.app_id()
 
     def discoverSchemaAsSmvSchema(self, path, csvAttributes, n=100000):
         """Discovers the schema of a .csv file and returns a Scala SmvSchema instance
@@ -491,7 +491,7 @@ class SmvApp(object):
 
     def abs_path_for_project_path(self, project_path):
         # Load dynamic app dir from scala
-        smvAppDir = self.config().appDir()
+        smvAppDir = self.py_smvconf.app_dir
         return os.path.abspath(os.path.join(smvAppDir, project_path))
 
     def prepend_source(self, project_path):
@@ -565,7 +565,7 @@ class SmvApp(object):
         """
         dot_graph_str = SmvAppInfo(self).create_graph_dot()
         if(self.cmd_line.graph):
-            path = "{}.dot".format(self.config().appName())
+            path = "{}.dot".format(self.appName())
             with open(path, "w") as f:
                 f.write(dot_graph_str)
             return True

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -449,11 +449,6 @@ class SmvApp(object):
         src = FileObjInputStream(fileobj)
         self._jvm.SmvHDFS.writeToFile(src, destination)
 
-    def urn2fqn(self, urnOrFqn):
-        """Extracts the SMV module FQN portion from its URN; if it's already an FQN return it unchanged
-        """
-        return self.j_smvPyClient.urn2fqn(urnOrFqn)
-
     def getStageFromModuleFqn(self, fqn):
         """Returns the stage name for a given fqn"""
         return self._jvm.org.tresamigos.smv.ModURN(fqn).getStage().get()

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -63,7 +63,7 @@ class SmvConfig(object):
     def reset_j_smvconf():
         """Reset scala side conf - for dynamic conf
         """
-        self.j_smvconf.reset(self.j_merged_props(), self.j_all_data_dirs())
+        self.j_smvconf.reset(self.merged_props(), self.all_data_dirs())
 
     def read_props_from_app_dir(self, _app_dir):
         """For a given app dir, read in the prop files
@@ -77,6 +77,17 @@ class SmvConfig(object):
         res = self.static_props.copy()
         res.update(self.dynamic_props)
         return res
+
+    def set_dynamic_props(self, new_d_props):
+        if(new_d_props):
+            self.dynamic_props = new_d_props.copy()
+            self.reset_j_smvconf()
+
+    def set_app_dir(self, new_app_dir):
+        if(new_app_dir):
+            self.app_dir = new_app_dir
+            self.read_props_from_app_dir(self.app_dir)
+            self.reset_j_smvconf()
 
     def all_data_dirs(self):
         """Create all the data dir configs

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -111,7 +111,7 @@ class SmvConfig(object):
     def stage_names(self):
         return self._split_prop("smv.stages")
 
-    def infer_stage_full_name(self, part_name):
+    def infer_full_stage_name(self, part_name):
         all_stages = self.stage_names()
         candidates = [s for s in all_stages if s.endswith(part_name)]
 

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -119,6 +119,15 @@ class SmvConfig(object):
             'publishDir': get_sub_dir('publishDir', 'publish')
         }
 
+    def app_id(self):
+        return self.merged_props().get("smv.appId")
+    
+    def app_name(self):
+        return self.merged_props().get("smv.appName")
+    
+    def user_libs(self):
+        return self._split_prop("smv.user_libraries")
+
     def stage_names(self):
         return self._split_prop("smv.stages")
 

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -53,9 +53,6 @@ class SmvConfig(object):
         java_import(self._jvm, "org.tresamigos.smv.SmvConfig2")
 
         self.j_smvconf = self._jvm.SmvConfig2(
-            self.mods_to_run,
-            self.stages_to_run,
-            self.cmdline, 
             self.merged_props(), 
             self.all_data_dirs()
         )

--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -60,7 +60,7 @@ class SmvConfig(object):
             self.all_data_dirs()
         )
 
-    def reset_j_smvconf():
+    def reset_j_smvconf(self):
         """Reset scala side conf - for dynamic conf
         """
         self.j_smvconf.reset(self.merged_props(), self.all_data_dirs())
@@ -131,7 +131,7 @@ class SmvConfig(object):
     def stage_names(self):
         return self._split_prop("smv.stages")
 
-    def infer_full_stage_name(self, part_name):
+    def infer_stage_full_name(self, part_name):
         all_stages = self.stage_names()
         candidates = [s for s in all_stages if s.endswith(part_name)]
 

--- a/src/main/python/smv/smvinput.py
+++ b/src/main/python/smv/smvinput.py
@@ -407,7 +407,7 @@ class SmvJdbcTable(SmvInputBase):
 
     def jdbcUrl(self):
         """User can override this, default use the jdbcUrl setting in smvConfig"""
-        return self.smvApp.config().jdbcUrl()
+        return self.smvApp.jdbcUrl()
 
     def readAsDF(self, readerLogger):
         if (self.tableQuery() is None):

--- a/src/main/scala/org/tresamigos/smv/DataSetMgr.scala
+++ b/src/main/scala/org/tresamigos/smv/DataSetMgr.scala
@@ -27,9 +27,9 @@ import scala.collection.mutable
  * arbitrary number of names so that all the target SmvDataSets
  * are loaded within the same transaction (which is much faster).
  */
-class DataSetMgr(smvConfig: SmvConfig) {
+class DataSetMgr(stageNames: Seq[String]) {
   private var dsRepoFactories: Seq[DataSetRepoFactory] = Seq.empty[DataSetRepoFactory]
-  private var allStageNames                            = smvConfig.stageNames
+  private var allStageNames                            = stageNames
 
   def register(newRepoFactory: DataSetRepoFactory): Unit = {
     dsRepoFactories = dsRepoFactories :+ newRepoFactory
@@ -51,7 +51,7 @@ class DataSetMgr(smvConfig: SmvConfig) {
    * every time
    */
   private[this] def withTX[T](func: TX => T): T =
-    func(new TX(dsRepoFactories, smvConfig))
+    func(new TX(dsRepoFactories, allStageNames))
 
   def load(urns: URN*): Seq[SmvDataSet] =
     withTX ( _.load(urns: _*) )

--- a/src/main/scala/org/tresamigos/smv/DataSetResolver.scala
+++ b/src/main/scala/org/tresamigos/smv/DataSetResolver.scala
@@ -28,8 +28,7 @@ import org.joda.time.DateTime
  * dependencies. DSR caches the SmvDataSets it has already resolved to ensure that
  * any SmvDataSet is only resolved once.
  */
-class DataSetResolver(val repos: Seq[DataSetRepo],
-                      smvConfig: SmvConfig) {
+class DataSetResolver(val repos: Seq[DataSetRepo]) {
   /**
    * Timestamp which will be injected into the resolved SmvDataSets
    */

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -55,7 +55,7 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
   val sqlContext = sparkSession.sqlContext
 
   // dsm should be private but will be temporarily public to accomodate outside invocations
-  val dsm = new DataSetMgr(smvConfig)
+  val dsm = new DataSetMgr(stages)
 
   // Since OldVersionHelper will be used by executors, need to inject the version from the driver
   OldVersionHelper.version = sc.version

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -39,7 +39,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
   val genEdd      = smvConfig.cmdLine.genEdd()
 
   def stages      = smvConfig.stageNames
-  def userLibs    = smvConfig.userLibs
 
   lazy val smvVersion  = {
     val smvHome = sys.env("SMV_HOME")

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -37,8 +37,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
   val log         = LogManager.getLogger("smv")
   val smvConfig   = new SmvConfig(cmdLineArgs)
   val genEdd      = smvConfig.cmdLine.genEdd()
-  val publishHive = smvConfig.cmdLine.publishHive()
-  val publishJDBC = smvConfig.cmdLine.publishJDBC()
 
   def stages      = smvConfig.stageNames
   def userLibs    = smvConfig.userLibs
@@ -67,32 +65,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
 
   lazy val allDataSets = dsm.allDataSets
 
-  /** list of all current valid output files in the output directory. All other files in output dir can be purged. */
-  private[smv] def validFilesInOutputDir(): Seq[String] =
-    allDataSets.flatMap(_.allOutputFiles).map(SmvHDFS.baseName(_))
-
-  /** remove all non-current files in the output directory */
-  private[smv] def purgeOldOutputFiles() = {
-    if (smvConfig.cmdLine.purgeOldOutput()) {
-      SmvHDFS.purgeDirectory(smvConfig.outputDir, validFilesInOutputDir()) foreach {
-        case (fn, success) =>
-          println(
-            if (success) s"... Deleted ${fn}"
-            else s"... Unabled to delete ${fn}"
-          )
-      }
-    }
-  }
-
-  /**
-   * Remove all current files (if any) in the output directory if --force-run-all
-   * argument was specified at the commandline
-   */
-  private[smv] def purgeCurrentOutputFiles() = {
-    if (smvConfig.cmdLine.forceRunAll())
-      deletePersistedResults(modulesToRunWithAncestors)
-  }
-
   /**
    * pass on the spark sql props set in the smv config file(s) to spark.
    * This is just for convenience so user can manage both smv/spark props in a single file.
@@ -101,82 +73,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
     for ((key, value) <- smvConfig.sparkSqlProps) {
       sqlContext.setConf(key, value)
     }
-  }
-
-  /**
-   * For each module, delete its persisted csv and schema (if any) with the
-   * modules current hash
-   */
-
-  private[smv] def deletePersistedResults(dsList: Seq[SmvDataSet]) =
-    dsList foreach (ds => ds.deleteOutputs(ds.versionedOutputFiles))
-
-  /**
-   * if the publish to hive flag is setn, the publish
-   */
-  def publishModulesToHive(collector: SmvRunInfoCollector): Boolean = {
-    if (publishHive) {
-      // filter out the outout modules and publish them
-      modulesToRun flatMap {
-        case m: SmvOutput => Some(m)
-        case _            => None
-      } foreach (
-          m => m.exportToHive(collector)
-      )
-    }
-
-    publishHive
-  }
-
-  /**
-   * if the export-csv option is specified, then publish locally
-   */
-  def publishOutputModulesLocally(collector: SmvRunInfoCollector): Boolean = {
-    if (smvConfig.cmdLine.exportCsv.isSupplied) {
-      val localDir = smvConfig.cmdLine.exportCsv()
-      modulesToRun foreach { m =>
-        val csvPath = s"${localDir}/${m.versionedFqn}.csv"
-        m.rdd(collector=collector).smvExportCsv(csvPath)
-      }
-    }
-
-    smvConfig.cmdLine.exportCsv.isSupplied
-  }
-
-  /**
-   * Publish through JDBC if the --publish-jdbc flag is set
-   */
-  def publishOutputModulesThroughJDBC(collector: SmvRunInfoCollector): Boolean = {
-    if (publishJDBC) {
-      modulesToRun foreach (_.publishThroughJDBC(collector))
-      true
-    } else {
-      false
-    }
-  }
-
-  /**
-   * Publish the specified modules if the "--publish" flag was specified on command line.
-   * @return true if modules were published, otherwise return false.
-   */
-  private[smv] def publishOutputModules(collector: SmvRunInfoCollector): Boolean = {
-    if (smvConfig.cmdLine.publish.isDefined) {
-      modulesToRun foreach { module =>
-        module.publish(collector=collector)
-      }
-      true
-    } else {
-      false
-    }
-  }
-
-  /**
-   * run the specified output modules.
-   * @return true if modules were generated, otherwise false.
-   */
-  private[smv] def generateOutputModules(collector: SmvRunInfoCollector): Boolean = {
-    modulesToRun foreach (_.rdd(collector=collector))
-    modulesToRun.nonEmpty
   }
 
   def getRunInfo(urn: URN): SmvRunInfoCollector = {
@@ -199,27 +95,6 @@ class SmvApp(private val cmdLineArgs: Seq[String], _spark: SparkSession) {
     coll
   }
 
-  /**
-   * sequence of SmvModules to run based on the command line arguments.
-   * Returns the union of -a/-m/-s command line flags.
-   */
-  lazy val modulesToRun: Seq[SmvDataSet] = {
-    val cmdline = smvConfig.cmdLine
-    val empty   = Some(Seq.empty[String])
-
-    val modPartialNames = cmdline.modsToRun.orElse(empty)()
-    val stageNames      = cmdline.stagesToRun.orElse(empty)() map (dsm.inferStageFullName(_))
-
-    dsm.modulesToRun(modPartialNames, stageNames, cmdline.runAllApp())
-  }
-
-  /**
-   * Sequence of SmvModules to run + all of their ancestors
-   */
-  lazy val modulesToRunWithAncestors: Seq[SmvDataSet] = {
-    val ancestors = modulesToRun flatMap (_.ancestors)
-    (modulesToRun ++ ancestors).distinct
-  }
 }
 
 /**

--- a/src/main/scala/org/tresamigos/smv/SmvConfig.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvConfig.scala
@@ -346,16 +346,10 @@ class SmvConfig(cmdLineArgs: Seq[String]) {
  *  Target interface for future SmvConfig class
  **/
 class SmvConfig2(
-  val modsToRun: ArrayList[String],
-  val stagesToRun: ArrayList[String],
-  val cmdLine: java.util.Map[String, String],
   var props: java.util.Map[String, String],
   var dataDirs: java.util.Map[String, String]
 ){
   def printall() = {
-    println(modsToRun)
-    println(stagesToRun)
-    println(cmdLine)
     println(props)
     println(dataDirs)
   }

--- a/src/main/scala/org/tresamigos/smv/Transaction.scala
+++ b/src/main/scala/org/tresamigos/smv/Transaction.scala
@@ -27,9 +27,9 @@ import org.apache.log4j.{LogManager, Level}
  * to run modules from the previous TX.
  */
 
-class TX(repoFactories: Seq[DataSetRepoFactory], smvConfig: SmvConfig) {
+class TX(repoFactories: Seq[DataSetRepoFactory], stageNames: Seq[String]) {
   val repos: Seq[DataSetRepo] = repoFactories map (_.createRepo)
-  val resolver                = new DataSetResolver(repos, smvConfig)
+  val resolver                = new DataSetResolver(repos)
   val log                     = LogManager.getLogger("smv")
 
   def load(urns: URN*): Seq[SmvDataSet] =
@@ -39,9 +39,9 @@ class TX(repoFactories: Seq[DataSetRepoFactory], smvConfig: SmvConfig) {
     repos flatMap (repo => stageNames flatMap (repo.urnsForStage(_)))
 
   def allUrns(): Seq[URN] = {
-    if (smvConfig.stageNames.isEmpty)
+    if (stageNames.isEmpty)
       log.warn("No stage names configured. Unable to discover any modules.")
-    urnsForStage(smvConfig.stageNames: _*)
+    urnsForStage(stageNames: _*)
   }
 
   def dataSetsForStage(stageNames: String*): Seq[SmvDataSet] =

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -282,8 +282,6 @@ class SmvPyClient(val j_smvApp: SmvApp) {
     j_smvApp.smvConfig.setAppDir(appDir)
   }
 
-  def userLibs: Array[String] = j_smvApp.userLibs.toArray
-
   // TODO: The following method should be removed when Scala side can
   // handle publish-hive SmvOutput tables
   def moduleNames: java.util.List[String] = {

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -268,8 +268,6 @@ class SmvMultiJoinAdaptor(joiner: SmvMultiJoin) {
 class SmvPyClient(val j_smvApp: SmvApp) {
   val config      = j_smvApp.smvConfig
 
-  def callbackServerPort: Option[Int] = config.cmdLine.cbsPort.get
-
   def publishVersion: Option[String] = config.cmdLine.publish.get
 
   def mergedPropsJSON: String = Serialization.write(j_smvApp.smvConfig.mergedProps)(org.json4s.DefaultFormats)

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -267,7 +267,6 @@ class SmvMultiJoinAdaptor(joiner: SmvMultiJoin) {
  */
 class SmvPyClient(val j_smvApp: SmvApp) {
   val config      = j_smvApp.smvConfig
-  val publishHive = j_smvApp.publishHive
 
   def callbackServerPort: Option[Int] = config.cmdLine.cbsPort.get
 

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -190,6 +190,11 @@ object SmvPythonHelper {
   //here to java.util.List
   def getDirList(dirPath: String): java.util.List[String] = SmvHDFS.dirList(dirPath)
 
+  private[smv] case class PurgeResult(fn: String, success: Boolean)
+  def purgeDirectory(dirName: String, keepFiles: ArrayList[String]): Seq[PurgeResult] = {
+    SmvHDFS.purgeDirectory(dirName, keepFiles.toSeq).map(r => PurgeResult(r._1, r._2))
+  }
+
   def dsmLoad(dsm: DataSetMgr, urns: Array[String]): java.util.List[SmvDataSet] = {
     val urnObjs = urns.map{URN(_)}
     dsm.load(urnObjs: _*)

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -268,8 +268,6 @@ class SmvMultiJoinAdaptor(joiner: SmvMultiJoin) {
 class SmvPyClient(val j_smvApp: SmvApp) {
   val config      = j_smvApp.smvConfig
 
-  def publishVersion: Option[String] = config.cmdLine.publish.get
-
   def mergedPropsJSON: String = Serialization.write(j_smvApp.smvConfig.mergedProps)(org.json4s.DefaultFormats)
 
   def setDynamicRunConfig(runConfig: java.util.Map[String, String]): Unit = {
@@ -283,11 +281,6 @@ class SmvPyClient(val j_smvApp: SmvApp) {
 
     j_smvApp.smvConfig.setAppDir(appDir)
   }
-
-  /** Output directory for files */
-  def outputDir: String = j_smvApp.smvConfig.outputDir
-
-  def stages: Array[String] = j_smvApp.stages.toArray
 
   def userLibs: Array[String] = j_smvApp.userLibs.toArray
 

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -284,8 +284,6 @@ class SmvPyClient(val j_smvApp: SmvApp) {
 
   def userLibs: Array[String] = j_smvApp.userLibs.toArray
 
-  def urn2fqn(modUrn: String): String = org.tresamigos.smv.urn2fqn(modUrn)
-
   // TODO: The following method should be removed when Scala side can
   // handle publish-hive SmvOutput tables
   def moduleNames: java.util.List[String] = {

--- a/src/main/scala/org/tresamigos/smv/urn.scala
+++ b/src/main/scala/org/tresamigos/smv/urn.scala
@@ -24,7 +24,7 @@ package org.tresamigos.smv
 sealed abstract class URN(prefix: String) {
   def fqn: String
   def getStage: Option[String] = {
-    val allStageNames = SmvApp.app.smvConfig.stageNames
+    val allStageNames = SmvApp.app.stages
 
     allStageNames.find { stageName =>
       fqn.startsWith(stageName + ".")

--- a/src/test/python/testDynamicConfigAppDir.py
+++ b/src/test/python/testDynamicConfigAppDir.py
@@ -39,7 +39,7 @@ class RunModuleWithDynamicConfigAppDirTest(SmvBaseTest):
 
         # capture the initial default app dir before each test. When the first test from this class
         # is run, this will be
-        self.initial_app_dir = self.smvApp.config().appDir()
+        self.initial_app_dir = self.smvApp.appDir()
 
     def tearDown(self):
         """ Reset the app dir to what it was initially after EACH test. Should be '.' '"""

--- a/src/test/python/testRunCmdLine.py
+++ b/src/test/python/testRunCmdLine.py
@@ -75,7 +75,14 @@ class RunModuleAmbiguousTest(RunCmdLineBaseTest):
         with self.assertRaisesRegexp(Py4JJavaError, r"Module name \[A\] is not specific enough"):
             self.smvApp.run()
 
+class SmvAppForceAllTest(RunCmdLineBaseTest):
+    @classmethod
+    def whatToRun(cls):
+        return ['-m', 'modules.A', '--force-run-all']
 
+    def test_should_force_run(self):
+        self.smvApp.run()
+    
 class SmvAppPurgeTest(SmvBaseTest):
     @classmethod
     def smvAppInitArgs(cls):

--- a/src/test/python/testRunCmdLine.py
+++ b/src/test/python/testRunCmdLine.py
@@ -125,6 +125,6 @@ class CreateDot(RunCmdLineBaseTest):
         import os
         self.smvApp.run()
 
-        dot_file = "{}.dot".format(self.smvApp.config().appName())
+        dot_file = "{}.dot".format(self.smvApp.appName())
         assert (os.path.isfile(dot_file) )
         os.remove(dot_file)

--- a/tools/templates/test/src/main/runners/custom_driver.py
+++ b/tools/templates/test/src/main/runners/custom_driver.py
@@ -7,7 +7,7 @@ class CustomDriver(SmvDriver):
         assert driver_args == expected_args, "Expected driver args {} but got {}".format(expected_args, driver_args)
         # verify that smv args are parsed correctly
         config_key = "smv.config.custom_key"
-        config_value = smvApp.config().mergedProps().apply(config_key)
+        config_value = smvApp.py_smvconf.merged_props().get(config_key)
         expected_value = "custom_value"
         assert config_value == expected_value, \
             "Expected config value for {} to be {} but got {}".format(config_key, config_value, expected_value) 


### PR DESCRIPTION
This is the step 2 of #1384. Including:

* Moved purge methods from scala SmvApp to python side
* Added dynamic conf support on python SmvConfig
* Minimize use of SmvConfig on Scala side
* Removed all the run method component methods from Scala SmvApp