### PR TITLE
 #1392 fixed the --run-app bug

### DIFF
--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -566,8 +566,8 @@ class SmvApp(object):
     def _generate_dot_graph(self):
         """Genrate app level graphviz dot file
         """
-        dot_graph_str = SmvAppInfo(self).create_graph_dot()
         if(self.cmd_line.graph):
+            dot_graph_str = SmvAppInfo(self).create_graph_dot()
             path = "{}.dot".format(self.appName())
             with open(path, "w") as f:
                 f.write(dot_graph_str)


### PR DESCRIPTION
The fix is simple, but the root cause of this bug is very deep, which relates on the way python modules get dynamically loaded. 

The problem was that when `create_graph_dot` get called out side of the if condition, it ran even if we just do `--run-app`. When it is called, one DSM call was made to load all modules, while the real `generate_output` need to load the output modules the second time. When the output module get reloaded, the dependency didn't, since they were loaded once already in the `create_graph_dot` call.