### PR TITLE
 #1400 made dynamic run config stick

### DIFF
--- a/src/main/python/smv/smvconfig.py
+++ b/src/main/python/smv/smvconfig.py
@@ -84,12 +84,11 @@ class SmvConfig(object):
     def set_dynamic_props(self, new_d_props):
         """Reset dynamic props
             Overwrite entire dynamic props fully each reset
+            Ignore reset if new_d_props is None
         """
-        if(new_d_props is None):
-            self.dynamic_props = {}
-        else:
+        if(new_d_props is not None):
             self.dynamic_props = new_d_props.copy()
-        self.reset_j_smvconf()
+            self.reset_j_smvconf()
 
     def set_app_dir(self, new_app_dir):
         """Dynamic reset of app dir, so that the location of app and user

--- a/src/test/python/testDynamicRunConfig.py
+++ b/src/test/python/testDynamicRunConfig.py
@@ -26,21 +26,30 @@ class RunModuleWithRunConfigTest(SmvBaseTest):
 
     def test_run_module_with_cmd_run_config(self):
         self.smvApp.run()
+        self.smvApp.setDynamicRunConfig({})
         res = self.smvApp.runModule(self.modUrn)[0]
         expected = self.createDF('src:String', 'cmd')
         self.should_be_same(expected, res)
 
     def test_run_module_with_dynamic_run_config(self):
         self.smvApp.run()
+        self.smvApp.setDynamicRunConfig({})
         a = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_a'})[0]
         self.should_be_same(self.createDF('src:String', 'dynamic_a'), a)
         b = self.smvApp.runModule(self.modUrn, runConfig = {'src': 'dynamic_b'})[0]
         self.should_be_same(self.createDF('src:String', 'dynamic_b'), b)
 
+        # Default runConfig=None leads to no change on the dynamic config
         c = self.smvApp.runModule(self.modUrn)[0]
-        self.should_be_same(self.createDF('src:String', 'cmd'), c)
+        self.should_be_same(self.createDF('src:String', 'dynamic_b'), c)
 
     def test_run_module_by_name_with_run_config(self):
+        self.smvApp.setDynamicRunConfig({})
         df, collector = self.smvApp.runModuleByName(self.modName)
         expected = self.createDF('src:String', 'cmd')
         self.should_be_same(expected, df)
+
+    def test_explicit_set_dynamic_run_config(self):
+        self.smvApp.setDynamicRunConfig({'src': 'dynamic_a'})
+        a = self.smvApp.runModule(self.modUrn)[0]
+        self.should_be_same(self.createDF('src:String', 'dynamic_a'), a)


### PR DESCRIPTION
Fixed #1400 

New behavior:
* `setDynamicRunConfig(None)` - ignore
* `setDynamicRunConfig({})` - reset to empty
* `setDynamicRunConfig({"a":1}) - over-write current dynamic run conf to `{"a":1}`

