### PR TITLE
I1347 step2 rm valid file

### DIFF
--- a/docs/user/dqm.md
+++ b/docs/user/dqm.md
@@ -3,9 +3,6 @@
 Both `SmvFile` and `SmvModule` has a "Validation" mechanism. SmvApp will
 automatically validate the result `DataFrame`.
 
-If the validation result is nontrivial, it will be persisted in a file with postfix `.valid` in the
-same location of the persisted data and schema files.
-
 If the validation result failed, the process will be terminated.
 
 Currently, there are 2 types of validations implemented,

--- a/src/main/python/smv/runinfo.py
+++ b/src/main/python/smv/runinfo.py
@@ -46,10 +46,10 @@ class SmvRunInfoCollector(object):
                 (e.g. caused by a typo in the name)
 
         """
-        java_result = self.jcollector.getDqmValidationResult(ds_name)
-        if java_result is None:
+        metadata = self.metadata(ds_name)
+        if (not metadata):
             return {}
-        return json.loads(java_result.toJSON())
+        return metadata["_validation"]
 
     def dqm_state(self, ds_name):
         """Returns the DQM state for a given dataset

--- a/src/main/python/smv/smvshell.py
+++ b/src/main/python/smv/smvshell.py
@@ -112,7 +112,7 @@ def openCsv(path, validate=False):
             return path
 
     # validator == None will use TerminateParserLogger, empty dqm means ignore errors
-    validator = None if validate else app._jvm.DQMValidator(dqm.SmvDQM(), False)
+    validator = None if validate else app._jvm.DQMValidator(dqm.SmvDQM())
     return DataFrame(TmpCsv(app).doRun(validator, None), app.sqlContext)
 
 def help():

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -491,7 +491,7 @@ abstract class SmvDataSet {
       persistMetadata(metadata)
       persistMetadataHistory(metadata, metadataHistory)
 
-      collector.addRunInfo(fqn, validationResult, metadata, metadataHistory)
+      collector.addRunInfo(fqn, metadata, metadataHistory)
     }
 
     if (quickRun) {
@@ -547,10 +547,9 @@ abstract class SmvDataSet {
    * null for its components.
    */
   def runInfo: SmvRunInfo = {
-    val validation = DQMValidator.readPersistedValidationFile(moduleValidPath()).toOption.orNull
     val meta = readPersistedMetadata().toOption.orNull
     val mhistory = readMetadataHistory().toOption.orNull
-    SmvRunInfo(validation, meta, mhistory)
+    SmvRunInfo(meta, mhistory)
   }
 
   /** path to published output without file extension **/

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -255,10 +255,6 @@ abstract class SmvDataSet {
   private def moduleEddPath(): String =
     versionedBasePath() + ".edd"
 
-  /** Returns the path for the module's reject report output */
-  private def moduleValidPath(): String =
-    versionedBasePath() + ".valid"
-
   /** Returns the path for the module's metadata output */
   private[smv] def moduleMetaPath(): String =
     versionedBasePath() + ".meta"
@@ -297,14 +293,14 @@ abstract class SmvDataSet {
    * Returns current all outputs produced by this module.
    */
   private[smv] def allOutputFiles(): Seq[String] = {
-    Seq(moduleCsvPath(), moduleSchemaPath(), moduleEddPath(), moduleValidPath(), moduleMetaPath(), moduleMetaHistoryPath())
+    Seq(moduleCsvPath(), moduleSchemaPath(), moduleEddPath(), moduleMetaPath(), moduleMetaHistoryPath())
   }
 
   /**
    * Returns current versioned outputs produced by this module. Excludes metadata history
    */
   private def versionedOutputFiles(): Seq[String] = {
-    Seq(moduleCsvPath(), moduleSchemaPath(), moduleEddPath(), moduleValidPath(), moduleMetaPath())
+    Seq(moduleCsvPath(), moduleSchemaPath(), moduleEddPath(), moduleMetaPath())
   }
 
   /**

--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -193,9 +193,6 @@ abstract class SmvDataSet {
     doAction(f"PUBLISH TO HIVE") {queries foreach {app.sqlContext.sql}}
   }
 
-  /** do not persist validation result if isObjectInShell **/
-  private def isPersistValidateResult = !isObjectInShell
-
   /**
    * Define the DQM rules, fixes and policies to be applied to this `DataSet`.
    * See [[org.tresamigos.smv.dqm]], [[org.tresamigos.smv.dqm.DQMRule]], and [[org.tresamigos.smv.dqm.DQMFix]]
@@ -472,12 +469,12 @@ abstract class SmvDataSet {
   private def computeDataFrame(genEdd: Boolean,
                                     collector: SmvRunInfoCollector,
                                     quickRun: Boolean): DataFrame = {
-    val dqmValidator  = new DQMValidator(dqmWithTypeSpecificPolicy(dqm), isPersistValidateResult)
+    val dqmValidator  = new DQMValidator(dqmWithTypeSpecificPolicy(dqm))
 
     // shared logic when running ephemeral and non-ephemeral modules
     def runDqmAndMeta(df: DataFrame, hasAction: Boolean): Unit = {
       val (validationResult, validationDuration) =
-        doAction(f"VALIDATE DATA QUALITY") {dqmValidator.validate(df, hasAction, moduleValidPath())}
+        doAction(f"VALIDATE DATA QUALITY") {dqmValidator.validate(df, hasAction)}
       dqmTimeElapsed = Some(validationDuration)
 
       val metadata = getOrCreateMetadata(Some(df), Some(validationResult))

--- a/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvRunInfoCollector.scala
@@ -28,10 +28,9 @@ class SmvRunInfoCollector {
    * previous result is replaced (last one wins).
    */
   def addRunInfo(dsFqn: String,
-    validation: DqmValidationResult,
     metadata: SmvMetadata,
     metadataHistory: SmvMetadataHistory): SmvRunInfoCollector =
-    addRunInfo(dsFqn, SmvRunInfo(validation, metadata, metadataHistory))
+    addRunInfo(dsFqn, SmvRunInfo(metadata, metadataHistory))
 
   def addRunInfo(dsFqn: String, runInfo: SmvRunInfo): SmvRunInfoCollector = {
     require(dsFqn != null && !dsFqn.isEmpty, s"Dataset FQN [$dsFqn] cannot be empty or null")
@@ -44,13 +43,6 @@ class SmvRunInfoCollector {
 
   /** For use by Python side */
   def dsFqnsAsJava: java.util.List[String] = dsFqns.toSeq.asJava
-
-  /**
-   * Returns the DQM validation result for a given dataset
-   *
-   * @throws NoSuchElementException if the dataset is not known to the collector
-   */
-  def getDqmValidationResult(dsName: String): DqmValidationResult = inferRunInfo(dsName).validation
 
   /**
    * Returns the metadata for a given dataset
@@ -90,4 +82,4 @@ class SmvRunInfoCollector {
   def inferRunInfo(dsName: String): SmvRunInfo = runInfo(inferFqn(dsName))
 }
 
-case class SmvRunInfo(validation: DqmValidationResult, metadata: SmvMetadata, metadataHistory: SmvMetadataHistory)
+case class SmvRunInfo(metadata: SmvMetadata, metadataHistory: SmvMetadataHistory)

--- a/src/test/scala/org/tresamigos/smv/DQMTest.scala
+++ b/src/test/scala/org/tresamigos/smv/DQMTest.scala
@@ -78,7 +78,7 @@ class DQMTest extends SmvTestUtil {
   test("test SmvDQM with FailAny (so FailCount)") {
     val df  = dfFrom("a:Integer;b:Double", "1,0.3;0,0.2")
 
-    val dqm = new DQMValidator(SmvDQM().add(DQMRule(col("a") <= 0, "a_le_0", FailAny)), false)
+    val dqm = new DQMValidator(SmvDQM().add(DQMRule(col("a") <= 0, "a_le_0", FailAny)))
 
     val res = dqm.attachTasks(df)
     assert(res.count === 1)
@@ -101,8 +101,8 @@ class DQMTest extends SmvTestUtil {
     val dqm = new DQMValidator(
       SmvDQM()
         .add(DQMRule(col("b") < 0.4, "b_lt_03", FailPercent(0.5)))
-        .add(DQMFix(col("a") < 1, lit(1) as "a", "a_lt_1_fix", FailPercent(0.3))),
-      false)
+        .add(DQMFix(col("a") < 1, lit(1) as "a", "a_lt_1_fix", FailPercent(0.3)))
+    )
 
     val res = dqm.attachTasks(df)
     assertSrddDataEqual(res, "1,0.3;1,0.2")
@@ -132,8 +132,8 @@ class DQMTest extends SmvTestUtil {
         .add(FailTotalRuleCountPolicy(2))
         .add(FailTotalFixCountPolicy(1))
         .add(FailTotalRulePercentPolicy(0.3))
-        .add(FailTotalFixPercentPolicy(0.3)),
-      false)
+        .add(FailTotalFixPercentPolicy(0.3))
+    )
 
     val res = dqm.attachTasks(df)
 

--- a/src/test/scala/org/tresamigos/smv/DQMTest.scala
+++ b/src/test/scala/org/tresamigos/smv/DQMTest.scala
@@ -160,8 +160,7 @@ class DQMTest extends SmvTestUtil {
         .add(BoundRule(col("a"), 0, 2))
         .add(SetRule(col("b"), Set("m", "f")))
         .add(FormatRule(col("c"), "."))
-        .add(FailTotalRuleCountPolicy(3)),
-      false
+        .add(FailTotalRuleCountPolicy(3))
     )
     val res = dqm.attachTasks(df)
     res.count
@@ -175,8 +174,7 @@ class DQMTest extends SmvTestUtil {
       SmvDQM()
         .add(SetFix(col("b"), Set("m", "f", "o"), "o"))
         .add(FormatFix(col("c"), ".", "_"))
-        .add(FailTotalFixCountPolicy(5)),
-      false
+        .add(FailTotalFixCountPolicy(5))
     )
     val res = dqm.attachTasks(df)
     assertSrddDataEqual(res, "1,m,a;0,f,c;2,m,z;1,o,x;1,m,_")
@@ -191,8 +189,7 @@ class DQMTest extends SmvTestUtil {
       SmvDQM()
         .add(DQMRule(col("b") < 0.4, "rule1"))
         .add(DQMFix(col("a") < 1, lit(1) as "a", "fix2"))
-        .add(DQMPolicy(policy, "udp")),
-      false
+        .add(DQMPolicy(policy, "udp"))
     )
 
     val res = dqm.attachTasks(df)

--- a/src/test/scala/org/tresamigos/smv/SmvRunInfoCollectorSpec.scala
+++ b/src/test/scala/org/tresamigos/smv/SmvRunInfoCollectorSpec.scala
@@ -17,36 +17,40 @@ package org.tresamigos.smv
 import dqm.DqmValidationResult
 
 class SmvRunInfoCollectorSpec extends SmvUnitSpec {
-  "SmvRunInfoCollector" should "store validation results per dataset" in {
+  "SmvRunInfoCollector" should "store metadata per dataset" in {
     val target = new SmvRunInfoCollector
     val r1 = new DqmValidationResult(true, null)
-    target.addRunInfo("a", r1, null, null)
+    val m1 = new SmvMetadata()
+    m1.addDqmValidationResult(r1)
+    target.addRunInfo("a", m1, null)
 
-    target.getDqmValidationResult("a") shouldBe r1
+    target.getMetadata("a") shouldBe m1
   }
 
   it should "throw when asked for a non-existent validation result" in {
     val target = new SmvRunInfoCollector
     intercept[SmvRuntimeException] {
-      target.getDqmValidationResult("a")
+      target.getMetadata("a")
     }
   }
 
   it should "store only the last validation result for a given dataset" in {
     val target = new SmvRunInfoCollector
-    val r1 = new DqmValidationResult(true, null)
-    val r2 = new DqmValidationResult(false, null)
-    target.addRunInfo("a", r1, null, null)
-    target.addRunInfo("a", r2, null, null)
+    val m1 = new SmvMetadata()
+    m1.addDqmValidationResult(new DqmValidationResult(true, null))
+    val m2 = new SmvMetadata()
+    m2.addDqmValidationResult(new DqmValidationResult(false, null))
+    target.addRunInfo("a", m1, null)
+    target.addRunInfo("a", m2,  null)
 
-    target.getDqmValidationResult("a") shouldBe r2
+    target.getMetadata("a") shouldBe m2
   }
 
   it should "keep all datasets for which there is a validation result" in {
     val target = new SmvRunInfoCollector
-    target.addRunInfo("a", new DqmValidationResult(true, null), null, null)
-    target.addRunInfo("b", new DqmValidationResult(false, null), null, null)
-    target.addRunInfo("c", new DqmValidationResult(false, null), null, null)
+    target.addRunInfo("a", null, null)
+    target.addRunInfo("b", null, null)
+    target.addRunInfo("c", null, null)
 
     target.dsFqns shouldBe Set("a", "b", "c")
   }
@@ -54,14 +58,14 @@ class SmvRunInfoCollectorSpec extends SmvUnitSpec {
   it should "not accept null for dataset fqn" in {
     val target = new SmvRunInfoCollector
     intercept[IllegalArgumentException] {
-      target.addRunInfo(null, new DqmValidationResult(true, null), null, null)
+      target.addRunInfo(null, null, null)
     }
   }
 
   it should "not accept empty string for dataset fqn" in {
     val target = new SmvRunInfoCollector
     intercept[IllegalArgumentException] {
-      target.addRunInfo("", new DqmValidationResult(true, null), null, null)
+      target.addRunInfo("", null, null)
     }
   }
 }


### PR DESCRIPTION
Step2 of #1347 

It also fixed #1259 (already closed).

Since validation result is already be part of the metadata, use the version in the metadata, instead of creating a separated persisted `.valid` file.