### PR TITLE
I1347 step3 edd to meta

### DIFF
--- a/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvDataSet.scala
@@ -116,9 +116,6 @@ abstract class SmvDataSet {
   /** full name of hive output table if this module is published to hive. */
   def tableName: String = throw new IllegalStateException("tableName not specified for ${fqn}")
 
-  /** Objects defined in Spark Shell has class name start with $ **/
-  private val isObjectInShell: Boolean = this.getClass.getName matches """\$.*"""
-
   /** Hash computed from the dataset, could be overridden to include things other than CRC */
   def datasetHash(): Int = {
     val _instanceValHash = instanceValHash

--- a/src/main/scala/org/tresamigos/smv/SmvMetaData.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvMetaData.scala
@@ -190,11 +190,19 @@ class SmvMetadata(val builder: MetadataBuilder = new MetadataBuilder) {
     sc.makeRDD(Seq(toJson), 1).saveAsTextFile(path)
 
   /**
-   * Add meta data from a Json string
+   * Add meta data from user defined metadata
    **/
   def addUserMeta(meta: Metadata) = {
     builder.putMetadata("_userMetadata", meta)
   }
+
+  /**
+   * Add Edd result as an array of meta
+   **/
+  def addEddResult(eddMetaArray: Array[Metadata]) = {
+    builder.putMetadataArray("_edd", eddMetaArray)
+  }
+
 }
 
 object SmvMetadata {

--- a/src/main/scala/org/tresamigos/smv/SmvMetaData.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvMetaData.scala
@@ -188,6 +188,13 @@ class SmvMetadata(val builder: MetadataBuilder = new MetadataBuilder) {
    */
   def saveToFile(sc: SparkContext, path: String) =
     sc.makeRDD(Seq(toJson), 1).saveAsTextFile(path)
+
+  /**
+   * Add meta data from a Json string
+   **/
+  def addUserMeta(meta: Metadata) = {
+    builder.putMetadata("_userMetadata", meta)
+  }
 }
 
 object SmvMetadata {

--- a/src/main/scala/org/tresamigos/smv/edd/Edd.scala
+++ b/src/main/scala/org/tresamigos/smv/edd/Edd.scala
@@ -17,6 +17,7 @@ package edd
 
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types.Metadata
 
 /**
  * Implement the `edd` method of DFHelper
@@ -81,6 +82,9 @@ class Edd(val df: DataFrame, val keys: Seq[String] = Seq()) {
   def persistBesideData(dataPath: String): Unit = {
     summary().saveReport(Edd.dataPathToEddPath(dataPath))
   }
+
+  def toMetaArray: Array[Metadata] = 
+    summary().toDF.toJSON.collect().map{Metadata.fromJson(_)}
 }
 
 /**

--- a/src/test/python/testRunCmdLine.py
+++ b/src/test/python/testRunCmdLine.py
@@ -129,3 +129,17 @@ class CreateDot(RunCmdLineBaseTest):
         dot_file = "{}.dot".format(self.smvApp.appName())
         assert (os.path.isfile(dot_file) )
         os.remove(dot_file)
+
+
+class CreateEdd(RunCmdLineBaseTest):
+    @classmethod
+    def whatToRun(cls):
+        return ['-m', 'modules.A', '--edd']
+
+    def test_run_module_with_edd(self):
+        self.smvApp.run()
+        coll = self.smvApp.getRunInfoByPartialName('modules.A', None)
+        edd_json_array = coll.metadata("modules.A")['_edd']
+        for r in edd_json_array:
+            if (r['colName'] == 'k' and r['taskDesc'] == "Non-Null Count"):
+                self.assertEqual(r['valueJSON'], '2')

--- a/src/test/python/testSmvFramework.py
+++ b/src/test/python/testSmvFramework.py
@@ -163,7 +163,7 @@ class SmvMetadataTest(SmvBaseTest):
         with open(self.tmpDataDir() + "/history/{}.hist/part-00000".format(fqn)) as f:
             metadata_list = json.loads(f.read())
             metadata = metadata_list['history'][0]
-        self.assertEqual(metadata['foo'], "bar")
+        self.assertEqual(metadata['_userMetadata']['foo'], "bar")
 
     def test_metadata_validation_failure_causes_error(self):
         fqn = "metadata_stage.modules.ModWithFailingValidation"


### PR DESCRIPTION
Step 3 of #1347 

We use to persist 
* Data (csv, schema)
* DQM (.valid)
* EDD (.edd) optional
* Meta (.meta, .history)

Step 2 removed `.valid`. This step removed `.edd` and moved edd result to another element of meta. 

Another change:
User meta is now **an element** of `SmvMetaData`, instead of is the `SmvMetaData`.