### PR TITLE
I1460 SmvApp no SC

### DIFF
--- a/src/main/python/scripts/smvserver.py
+++ b/src/main/python/scripts/smvserver.py
@@ -16,6 +16,7 @@ import fnmatch
 import re
 import glob
 from flask import Flask, request, jsonify
+from pyspark.sql import SparkSession
 from smv import SmvApp
 from smv.smvapp import DataSetRepoFactory
 
@@ -67,7 +68,11 @@ class Main(object):
         options = self.parseArgs()
 
         # init Smv context
-        smvApp = SmvApp.createInstance([])
+        sparkSession = SparkSession.builder.\
+                enableHiveSupport().\
+                getOrCreate() 
+
+        smvApp = SmvApp.createInstance([], sparkSession)
 
         # to reduce complexity in SmvApp, keep the rest server single-threaded
         app.run(host=options.ip, port=int(options.port), threaded=False, processes=1)

--- a/src/main/python/smv/datasetmgr.py
+++ b/src/main/python/smv/datasetmgr.py
@@ -22,9 +22,8 @@ class DataSetMgr(object):
     """The Python representation of DataSetMgr.
     """
 
-    def __init__(self, sc, smvconfig):
-        self.sc = sc
-        self._jvm = sc._jvm
+    def __init__(self, _jvm, smvconfig):
+        self._jvm = _jvm
 
         self.smvconfig = smvconfig
         self.dsRepoFactories = []

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -84,15 +84,8 @@ class SmvApp(object):
         """
         cls._instance = app
 
-    def __init__(self, arglist, _sparkSession=None, py_module_hotload=True):
-        if (_sparkSession is None):
-            self.sparkSession = SparkSession.builder.\
-                    enableHiveSupport().\
-                    getOrCreate() 
-        elif (_sparkSession == "SkipSpark"):
-            self.sparkSession = None
-        else:
-            self.sparkSession = _sparkSession
+    def __init__(self, arglist, _sparkSession, py_module_hotload=True):
+        self.sparkSession = _sparkSession
 
         if (self.sparkSession is not None):
             sc = self.sparkSession.sparkContext

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -22,6 +22,7 @@ import json
 from collections import namedtuple
 
 from py4j.java_gateway import java_import, JavaObject
+from pyspark.java_gateway import launch_gateway
 from pyspark import SparkContext
 from pyspark.sql import SparkSession, DataFrame
 
@@ -40,6 +41,8 @@ from smv.smviostrategy import SmvJsonOnHdfsIoStrategy
 from smv.smvmetadata import SmvMetaHistory
 from smv.smvhdfs import SmvHDFS
 from py4j.protocol import Py4JJavaError
+
+
 
 class SmvApp(object):
     """The Python representation of SMV.
@@ -82,20 +85,31 @@ class SmvApp(object):
         cls._instance = app
 
     def __init__(self, arglist, _sparkSession=None, py_module_hotload=True):
-        self.sparkSession = SparkSession.builder.\
+        if (_sparkSession is None):
+            self.sparkSession = SparkSession.builder.\
                     enableHiveSupport().\
-                    getOrCreate() if _sparkSession is None else _sparkSession
+                    getOrCreate() 
+        elif (_sparkSession == "SkipSpark"):
+            self.sparkSession = None
+        else:
+            self.sparkSession = _sparkSession
 
-        sc = self.sparkSession.sparkContext
-        sc.setLogLevel("ERROR")
+        if (self.sparkSession is not None):
+            sc = self.sparkSession.sparkContext
+            sc.setLogLevel("ERROR")
 
-        self.sc = sc
-        self.sqlContext = self.sparkSession._wrapped
-        self._jvm = sc._jvm
+            self.sc = sc
+            self.sqlContext = self.sparkSession._wrapped
+            self._jvm = sc._jvm
+            self.j_smvPyClient = self._jvm.org.tresamigos.smv.python.SmvPyClientFactory.init(self.sparkSession._jsparkSession)
+            self.j_smvApp = self.j_smvPyClient.j_smvApp()
+        else:
+            _gw = launch_gateway(None)
+            self._jvm = _gw.jvm
 
+        self.log = self._jvm.org.apache.log4j.LogManager.getLogger("smv")
         self.py_module_hotload = py_module_hotload
 
-        from py4j.java_gateway import java_import
         java_import(self._jvm, "org.tresamigos.smv.ColumnHelper")
         java_import(self._jvm, "org.tresamigos.smv.SmvDFHelper")
         java_import(self._jvm, "org.tresamigos.smv.dqm.*")
@@ -105,20 +119,22 @@ class SmvApp(object):
         java_import(self._jvm, "org.tresamigos.smv.DfCreator")
 
         self.py_smvconf = SmvConfig(arglist, self._jvm)
-        self.j_smvPyClient = self.create_smv_pyclient()
 
         # configure spark sql params 
-        for k, v in self.py_smvconf.spark_sql_props().items():
-            self.sqlContext.setConf(k, v)
+        if (self.sparkSession is not None):
+            for k, v in self.py_smvconf.spark_sql_props().items():
+                self.sqlContext.setConf(k, v)
+
+        # issue #429 set application name from smv config
+        if (self.sparkSession is not None):
+            sc._conf.setAppName(self.appName())
 
         # CmdLine is static, so can be an attribute
         cl = self.py_smvconf.cmdline
         self.cmd_line = namedtuple("CmdLine", cl.keys())(*cl.values())
 
         # shortcut is meant for internal use only
-        self.j_smvApp = self.j_smvPyClient.j_smvApp()
-        self.log = self.j_smvApp.log()
-        self.dsm = DataSetMgr(self.sc, self.py_smvconf)
+        self.dsm = DataSetMgr(self._jvm, self.py_smvconf)
 
         # computed df cache, keyed by m.versioned_fqn
         self.df_cache = {}
@@ -126,9 +142,6 @@ class SmvApp(object):
         # AFTER app is available but BEFORE stages,
         # use the dynamically configured app dir to set the source path, library path
         self.prependDefaultDirs()
-
-        # issue #429 set application name from smv config
-        sc._conf.setAppName(self.appName())
 
         self.repoFactory = DataSetRepoFactory(self)
         self.dsm.register(self.repoFactory)
@@ -262,13 +275,6 @@ class SmvApp(object):
         """
         all_files = self._jvm.SmvPythonHelper.getDirList(self.inputDir())
         return [str(f) for f in all_files if f.endswith(ftype)]
-
-    def create_smv_pyclient(self):
-        '''
-        return a smvPyClient instance
-        '''
-        # convert python arglist to java String array
-        return self._jvm.org.tresamigos.smv.python.SmvPyClientFactory.init(self.sparkSession._jsparkSession)
 
     def get_graph_json(self):
         """Generate a json string representing the dependency graph.

--- a/src/main/python/smv/smvdriver.py
+++ b/src/main/python/smv/smvdriver.py
@@ -1,5 +1,6 @@
 import sys
 
+from pyspark.sql import SparkSession
 from smv import SmvApp
 
 class SmvDriver(object):
@@ -21,9 +22,12 @@ class SmvDriver(object):
                 smv_args (list(str)): CLI args for SMV - should be passed to `SmvApp`)
                 driver_args (list(str)): CLI args for the driver
         """
+        sparkSession = SparkSession.builder.\
+                enableHiveSupport().\
+                getOrCreate() 
         # When SmvDriver is in use, user will call smv-run and interact
         # through command-line, so no need to do py module hotload
-        return SmvApp.createInstance(smv_args, py_module_hotload=False)
+        return SmvApp.createInstance(smv_args, sparkSession, py_module_hotload=False)
 
     def main(self, app, driver_args):
         """Override this to define the driver logic 

--- a/src/main/python/smv/smviostrategy.py
+++ b/src/main/python/smv/smviostrategy.py
@@ -134,15 +134,9 @@ class SmvCsvOnHdfsIoStrategy(SmvFileOnHdfsIoStrategy):
         return DataFrame(jdf, self.smvApp.sqlContext)
 
     def isPersisted(self):
-        handler = self.smvApp.j_smvPyClient.createFileIOHandler(self._file_path)
-
         # since within the persistDF call on scala side, schema was written after
         # csv file, so we can use the schema file as a semaphore
-        try:
-            handler.readSchema()
-            return True
-        except:
-            return False
+        return self.smvApp._jvm.SmvHDFS.exists(self._schema_path)
 
     def remove(self):
         self.smvApp._jvm.SmvHDFS.deleteFile(self._file_path)

--- a/src/test/python/testSmvFramework2.py
+++ b/src/test/python/testSmvFramework2.py
@@ -206,7 +206,7 @@ class SmvAppWithoutSparkTest(SmvBaseTest):
         args = TestConfig.smv_args() + cls.smvAppInitArgs() + ['--data-dir', cls.tmpDataDir()]
         # The test's SmvApp must be set as the singleton for correct results of some tests
         # The original SmvApp (if any) will be restored when the test is torn down
-        cls.smvApp = SmvApp.createInstance(args, "SkipSpark")
+        cls.smvApp = SmvApp.createInstance(args, None)
 
         sys.path.append(cls.resourceTestDir())
 


### PR DESCRIPTION
Fixed #1460 

Changed the signature of SmvApp's constructor to:
```python
__init__(self, arglist, _sparkSession, py_module_hotload=True):
```

So it's caller's responsibility to provide the SparkSession. If it is None, create an SmvApp instance without SparkSession, but with _jvm.