### PR TITLE
I1469 meta closer to run

### DIFF
--- a/src/main/python/smv/smvgenericmodule.py
+++ b/src/main/python/smv/smvgenericmodule.py
@@ -354,6 +354,7 @@ class SmvGenericModule(ABC):
             Args:
                 urn2df({str:DataFrame}) already run modules current module may depends
                 run_set(set(SmvGenericModule)) modules yet to run post_action
+                collector(SmvRunInfoCollector) collect runinfo of current run
                 forceRun(bool) ignore DF cache in smvApp
                 is_quick_run(bool) skip meta, dqm, persist, but use persisted as possible
 
@@ -491,6 +492,7 @@ class SmvGenericModule(ABC):
                 mod.post_action()
                 meta_io_strategy = mod.metaStrategy()
                 if (not_persisted_or_no_edd_when_forced(meta_io_strategy)):
+                    # data cache should be populated by this step
                     if (mod.data is None):
                         raise SmvRuntimeError("Module {}'s data is None, can't run postAction".format(mod.fqn()))
                     # Since the ancestor list will be visited as depth-first, although 

--- a/src/main/python/smv/smvmodulerunner.py
+++ b/src/main/python/smv/smvmodulerunner.py
@@ -44,8 +44,13 @@ class SmvModuleRunner(object):
 
         collector = SmvRunInfoCollector()
 
+        # Do the real module calculation, when there are persistence, run
+        # the post_actions and ancestor ephemeral modules post actions
         self._create_df(known, mods_to_run_post_action, collector, forceRun)
 
+        # If there are ephemeral modules who has no persisting module
+        # down stream, (must be part of roots), force an action and run
+        # post actions
         self._force_post(mods_to_run_post_action, collector)
 
         dfs = [m.data for m in self.roots]

--- a/src/test/python/testSmvFramework2.py
+++ b/src/test/python/testSmvFramework2.py
@@ -99,25 +99,6 @@ class SmvFrameworkTest2(SmvBaseTest):
         self.assertEqual(m.module_meta._metadata['_fqn'], fqn)
         self.assertEqual(rule_cnt, 1)
 
-    def test_metadata_action_trigger_validation(self):
-        """M3 is ephemeral and non-trivial metadata, it should trigger post_action"""
-
-        fqn = "stage.modules.M3"
-        m = self.load(fqn)[0]
-
-        runner = SmvModuleRunner([m], self.smvApp)
-
-        # runner's run logic below, without the last force run
-        mods_to_run_post_action = set(runner.visitor.queue)
-        known = {}
-        runner._create_df(known, mods_to_run_post_action)
-        runner._create_meta(mods_to_run_post_action)
-
-        # by now, since M3 has non-trivial metadata, it triggers post_action,
-        # so should be removed from the mods_to_run_post_action
-
-        self.assertEqual(len(mods_to_run_post_action), 0)
-
     def test_metadata_persist(self):
         fqn = "stage.modules.M1"
         m = self.load(fqn)[0]


### PR DESCRIPTION
Fixed #1469 

Moved meta calculation, validation, persisting, hist update & persisting all into run_ancestor_and_me_postAction method. 

The run method of runner reduced to 2 visits, one for run, one for handle leftover ephemeral post actions.