### PR TITLE
I1509: use python to initialize git repo

### DIFF
--- a/docker/smv/requirements.txt
+++ b/docker/smv/requirements.txt
@@ -1,3 +1,4 @@
+dulwich
 Flask
 # iPython 6+ does not support Python < 3.3, so need to pin this for Python2 support
 # https://ipython.readthedocs.io/en/stable/whatsnew/version5.html

--- a/tools/git_helper.py
+++ b/tools/git_helper.py
@@ -1,0 +1,43 @@
+import argparse
+import dulwich.porcelain
+
+class GitHelper(object):
+    """Git helper for initializing git repository
+        and committing all unstaged and untracked files.
+    """
+    def __init__(self, repo_dir):
+        self.repo_dir = repo_dir
+
+    def init_repo(self):
+        dulwich.porcelain.init(self.repo_dir)
+        self.commit_unstaged_and_untracked("init git repository")
+
+    def commit_unstaged_and_untracked(self, commit_msg=""):
+        repo = dulwich.porcelain.open_repo(self.repo_dir)
+        status = dulwich.porcelain.status(repo)
+        repo.stage(status.unstaged + status.untracked)
+        dulwich.porcelain.commit(repo, commit_msg)
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        usage="python git_helper.py -o init/commit -d ~/repo_dir -m 'commit_msg'",
+    )
+
+    parser.add_argument('-o', dest='op', help="Operation: either 'init' or 'commit'")
+    parser.add_argument('-d', dest='repo_dir', default=".", help="Git repo directory")
+    parser.add_argument('-m', dest='commit_msg', default="", help="Git commit message")
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    op = args.op
+    if op in ["init", "commit"]:
+        gitHelper = GitHelper(args.repo_dir)
+        if op == "init":
+            gitHelper.init_repo()
+        else:
+            gitHelper.commit_unstaged_and_untracked(args.commit_msg)
+    else:
+        raise Exception("Invalid op: {}, only 'init' and 'commit' are valid!".format(op))

--- a/tools/smv-init
+++ b/tools/smv-init
@@ -210,7 +210,7 @@ function create_git_structure()
     if [ "$DO_GIT_INIT" = 1 ]; then
         echo "-- initializing git repository"
 
-        cd ${PROJ_DIR_FULL_PATH} && git init && git add . && git commit -m "init commit"
+        cd ${PROJ_DIR_FULL_PATH} && python ${SMV_TOOLS}/git_helper.py -o init
     fi
 }
 


### PR DESCRIPTION
Fixes #1509 

The `git log` of the repo which initialized by using python looks like:
```
eddie@b55c706dfa6d:~/testInit$ git log
commit 2809c753789d9f56161c1bda82fbb79a1f4d2e2b
Author: eddie <eddie@b55c706dfa6d>
Date:   Mon Nov 19 08:35:07 2018 +0000

    init git repository
```