### PR TITLE
I1503 step2 jdbc hive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,12 @@ setuptools.setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     tests_require=['sphinx', 'tox'],
-    packages=[
-        'smv',
+    # Need to call find_packages so that newly introduced
+    # sub-packages will be included
+    packages=setuptools.find_packages(
+        "src/main/python",
+        exclude=['test_support', 'scripts']
+    ) + [
         'smv.target',
         'smv.docker',
         'smv.docs',

--- a/src/main/python/smv/smvinput.py
+++ b/src/main/python/smv/smvinput.py
@@ -358,53 +358,6 @@ class SmvCsvStringData(WithParser):
         """
 
 
-class SmvJdbcTable(SmvInputBase):
-    """Input from a table read through JDBC
-    """
-    def description(self):
-        return "JDBC table {}".format(self.tableName())
-
-    def jdbcUrl(self):
-        """User can override this, default use the jdbcUrl setting in smvConfig"""
-        return self.smvApp.jdbcUrl()
-
-    def readAsDF(self):
-        if (self.tableQuery() is None):
-            tableNameOrQuery = self.tableName()
-        else:
-            tableNameOrQuery = "({}) as TMP_{}".format(
-                self.tableQuery(), self.tableName()
-            )
-
-        return self.smvApp.sqlContext.read\
-            .format('jdbc')\
-            .option('url', self.jdbcUrl())\
-            .option('dbtable', tableNameOrQuery)\
-            .load()
-
-    @abc.abstractmethod
-    def tableName(self):
-        """User-specified name for the table to extract input from
-
-            Override this to specify your own table name.
-
-            Returns:
-                (str): table name
-        """
-        pass
-
-    def tableQuery(self):
-        """Query used to extract data from Hive table
-
-            Override this to specify your own query (optional). Default is
-            equivalent to 'select * from ' + tableName().
-
-            Returns:
-                (str): query
-        """
-        return None
-
-
 class SmvHiveTable(SmvInputBase):
     """Input from a Hive table
     """

--- a/src/test/python/testHive.py
+++ b/src/test/python/testHive.py
@@ -91,11 +91,6 @@ class ReadHiveTableTest(HiveTest):
         hiveDf = self.df("stage.modules.MyHive")
         self.should_be_same(mDf,hiveDf)
 
-    def test_smv_hive_table_can_use_custom_query(self):
-        mDf = self.df("stage.modules.M").select("k")
-        hiveDf = self.df("stage.modules.MyHiveWithQuery")
-        self.should_be_same(mDf,hiveDf)
-
 class NewHiveTableTest(HiveTest):
     @classmethod
     def smvAppInitArgs(cls):

--- a/src/test/python/testHive/stage/modules.py
+++ b/src/test/python/testHive/stage/modules.py
@@ -31,10 +31,6 @@ class MAdv(SmvModule, SmvOutput):
 class MyHive(SmvHiveTable):
     def tableName(self): return "M"
 
-class MyHiveWithQuery(SmvHiveTable):
-    def tableName(self): return "M"
-    def tableQuery(self): return "from M select k"
-
 
 class NewHiveInput(SmvHiveInputTable):
     def tableName(self): return "M"

--- a/src/test/python/testJdbc.py
+++ b/src/test/python/testJdbc.py
@@ -15,50 +15,6 @@ from test_support.smvbasetest import SmvBaseTest
 from pyspark.sql import DataFrame
 from smv.smvmodulerunner import SmvModuleRunner
 
-class JdbcTest(SmvBaseTest):
-    @classmethod
-    def setUpClass(cls):
-        super(JdbcTest, cls).setUpClass()
-        cls.smvApp._jvm.org.tresamigos.smv.jdbc.JdbcDialectHelper.registerDerby()
-
-    @classmethod
-    def url(cls):
-        return "jdbc:derby:" + cls.tmpTestDir() + "/derby;create=true"
-
-    @classmethod
-    def driver(cls):
-        return "org.apache.derby.jdbc.EmbeddedDriver"
-
-    @classmethod
-    def smvAppInitArgs(cls):
-        return [
-            "--smv-props", 
-            "smv.stages=stage", 
-            "smv.jdbc.url=" + cls.url(),
-            "smv.jdbc.driver=" + cls.driver()
-        ]
-
-    def test_SmvJdbcTable(self):
-        df = self.createDF("K:String", "xxx")
-        df.write.jdbc(self.url(), "MyJdbcTable", properties={"driver": "org.apache.derby.jdbc.EmbeddedDriver"})
-        res = self.df("stage.modules.MyJdbcTable")
-        res2 = self.df("stage.modules.MyJdbcWithQuery")
-        self.should_be_same(res, df)
-        self.should_be_same(res2, df)
-
-    def test_publish_to_jdbc(self):
-        fqn = "stage.modules.MyJdbcModule"
-        m = self.load(fqn)[0]
-        res = self.df(fqn)
-        SmvModuleRunner([m], self.smvApp).publish_to_jdbc()
-        readback = self.smvApp.sqlContext.read\
-            .format("jdbc")\
-            .option("url", self.url())\
-            .option("dbtable", "MyJdbcModule")\
-            .load()
-
-        self.should_be_same(res, readback)
-
 
 class NewJdbcTest(SmvBaseTest):
     @classmethod
@@ -77,8 +33,8 @@ class NewJdbcTest(SmvBaseTest):
     @classmethod
     def smvAppInitArgs(cls):
         return [
-            "--smv-props", 
-            "smv.stages=stage", 
+            "--smv-props",
+            "smv.stages=stage",
             "smv.conn.myjdbc_conn.class=smv.conn.SmvJdbcConnectionInfo",
             "smv.conn.myjdbc_conn.url=" + cls.url(),
             "smv.conn.myjdbc_conn.driver=" + cls.driver()
@@ -99,4 +55,3 @@ class NewJdbcTest(SmvBaseTest):
             .option("dbtable", "MyJdbcTable")\
             .load()
         self.should_be_same(res, df)
-    

--- a/src/test/python/testJdbc/stage/modules.py
+++ b/src/test/python/testJdbc/stage/modules.py
@@ -14,31 +14,9 @@
 from smv import *
 from smv.iomod import SmvJdbcInputTable, SmvJdbcOutputTable
 
-class MyJdbcTable(SmvJdbcTable):
-    def tableName(self):
-        return "MyJdbcTable"
-
-class MyJdbcWithQuery(SmvJdbcTable):
-    def tableQuery(self):
-        return "select K from MyJdbcTable"
-    def tableName(self):
-        return "MyJdbcTable"
-
-class MyJdbcCsvString(SmvCsvStringData, SmvOutput):
-    def tableName(self):
-        return "MyJdbcOutput"
-
-    def schemaStr(self):
-        return "a:String;b:Integer"
-    def dataStr(self):
-        return "x,10;y,1"
-
 class MyJdbcModule(SmvModule):
     def requiresDS(self):
         return []
-
-    def tableName(self):
-        return "MyJdbcModule"
 
     def run(self, i):
         return self.smvApp.createDF("a:String", "1")
@@ -54,7 +32,7 @@ class NewJdbcTable(SmvJdbcInputTable):
 class NewJdbcOutputTable(SmvJdbcOutputTable):
     def requiresDS(self):
         return [MyJdbcModule]
-    
+
     def tableName(self):
         return "MyJdbcTable"
 


### PR DESCRIPTION
Step 2 of #1503 

Since `SmvJdbcTable` in `smvinput` was rarely used in projects, simply removed it (replaced by the `iomod.SmvJdbcInputTable`).

`SmvHiveTable` was used in multiple projects, so still keep for now. However "query-on-read" is no more supported. 

 