### PR TITLE
I1512 jvmless logging

### DIFF
--- a/docs/user/dqm.md
+++ b/docs/user/dqm.md
@@ -41,8 +41,7 @@ class Myfile(smv.SmvCsvFile):
 
 With above setting, the `SmvCsvFile` will simply persist the validation result and keep moving.
 
-Either terminating the process or not, as long as the log is nontrivial, it will be logged in
-log4j with level "warning".
+Either terminating the process or not, as long as the log is nontrivial, it will be logged with level "warning".
 The result will also by persisted in the `SmvModule` persisted metadata with postfix `.meta`.
 
 Sometimes we need more flexibility on specifying the terminate criteria. For example, I can tolerate

--- a/log4j.properties
+++ b/log4j.properties
@@ -9,6 +9,3 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: 
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
-
-# Un-comment to turn on smv debug log
-log4j.logger.smv=INFO

--- a/src/main/python/smv/__init__.py
+++ b/src/main/python/smv/__init__.py
@@ -19,9 +19,12 @@ SmvPyModuleLink = SmvModuleLink
 
 import logging
 logger = logging.getLogger(__name__)
-stderr_appender = logging.StreamHandler()
-
-# Default logging setting
+# Default logging settings
 # These may be overridden when SmvApp initializes
+log_formatter = logging.Formatter(
+    fmt='%(asctime)s %(levelname)s %(name)s: %(message)s',
+    datefmt='%m/%d/%Y %I:%M:%S')
+stderr_log_appender = logging.StreamHandler()
+stderr_log_appender.setFormatter(log_formatter)
+logger.addHandler(stderr_log_appender)
 logger.setLevel("INFO")
-logger.addHandler(stderr_appender)

--- a/src/main/python/smv/__init__.py
+++ b/src/main/python/smv/__init__.py
@@ -16,3 +16,12 @@ SmvPyCsvFile = SmvCsvFile
 SmvPyModule = SmvModule
 SmvPyOutput = SmvOutput
 SmvPyModuleLink = SmvModuleLink
+
+import logging
+logger = logging.getLogger(__name__)
+stderr_appender = logging.StreamHandler()
+
+# Default logging setting
+# These may be overridden when SmvApp initializes
+logger.setLevel("INFO")
+logger.addHandler(stderr_appender)

--- a/src/main/python/smv/datasetmgr.py
+++ b/src/main/python/smv/datasetmgr.py
@@ -14,6 +14,7 @@
 """DataSetMgr entry class
 This module provides the python entry point to DataSetMgr on scala side
 """
+import smv
 
 from smv.utils import smv_copy_array, scala_seq_to_list, list_distinct, infer_full_name_from_part
 from smv.datasetresolver import DataSetResolver
@@ -130,7 +131,7 @@ class TX(object):
         self.repos = [rf.createRepo() for rf in resourceFactories]
         self.stages = stages
         self.resolver = DataSetResolver(self.repos[0])
-        self.log = _jvm.org.apache.log4j.LogManager.getLogger("smv")
+        self.log = smv.logger
 
     def load(self, urns):
         fqns = [u[4:] for u in urns]

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -101,8 +101,6 @@ class SmvApp(object):
             _gw = launch_gateway(None)
             self._jvm = _gw.jvm
 
-        self.log = smv.logger
-
         self.py_module_hotload = py_module_hotload
 
         java_import(self._jvm, "org.tresamigos.smv.ColumnHelper")
@@ -218,8 +216,8 @@ class SmvApp(object):
         # the app properties to be read from disk and reevaluated
         self.py_smvconf.set_app_dir(appDir)
 
-        self.log.info("Set app dir to " + appDir)
-        self.log.debug("Current SMV configuration: {}".format(self.py_smvconf.merged_props()))
+        smv.logger.info("Set app dir to " + appDir)
+        smv.logger.debug("Current SMV configuration: {}".format(self.py_smvconf.merged_props()))
 
         # this call will use the dynamic appDir that we just set ^
         # to change sys.path, allowing py modules, UDL's to be discovered by python
@@ -517,13 +515,13 @@ class SmvApp(object):
         abs_path = self.abs_path_for_project_path(project_path)
         # Source must be added to front of path to make sure it is found first
         sys.path.insert(1, abs_path)
-        self.log.debug("Prepended {} to sys.path".format(abs_path))
+        smv.logger.debug("Prepended {} to sys.path".format(abs_path))
 
     def remove_source(self, project_path):
         try:
             abs_path = self.abs_path_for_project_path(project_path)
             sys.path.remove(abs_path)
-            self.log.debug("Removed {} from sys.path".format(abs_path))
+            smv.logger.debug("Removed {} from sys.path".format(abs_path))
         except ValueError:
             # ValueError will be raised if the project path was not previously
             # added to the sys.path

--- a/src/main/python/smv/smvapp.py
+++ b/src/main/python/smv/smvapp.py
@@ -101,7 +101,8 @@ class SmvApp(object):
             _gw = launch_gateway(None)
             self._jvm = _gw.jvm
 
-        self.log = self._jvm.org.apache.log4j.LogManager.getLogger("smv")
+        self.log = smv.logger
+
         self.py_module_hotload = py_module_hotload
 
         java_import(self._jvm, "org.tresamigos.smv.ColumnHelper")

--- a/src/main/python/smv/smvinput.py
+++ b/src/main/python/smv/smvinput.py
@@ -23,6 +23,7 @@ import sys
 import json
 import re
 
+import smv
 from smv.dqm import FailParserCountPolicy
 from smv.error import SmvRuntimeError
 from smv.smvmodule import SmvSparkDfModule
@@ -95,7 +96,7 @@ class SmvInputBase(SmvSparkDfModule, ABC):
         data_src_hash = self.dataSrcHash()
         res = data_src_hash + schema_hash
 
-        self.smvApp.log.debug("{}.instanceValHash = {}".format(self.fqn(), res))
+        smv.logger.debug("{}.instanceValHash = {}".format(self.fqn(), res))
 
         # ensure python's numeric type can fit in a java.lang.Integer
         return int(res) & 0x7fffffff
@@ -143,12 +144,12 @@ class SmvInputFromFile(SmvInputBase):
             Based on file's mtime, and file's full path
         """
         full_path = self.fullPath()
-        self.smvApp.log.debug("{} input path: {}".format(self.fqn(), full_path))
+        smv.logger.debug("{} input path: {}".format(self.fqn(), full_path))
 
         path_hash = smvhash(full_path)
 
         m_time = self.smvApp._jvm.SmvHDFS.modificationTime(full_path)
-        self.smvApp.log.debug("{} input m_time: {}".format(self.fqn(), m_time))
+        smv.logger.debug("{} input m_time: {}".format(self.fqn(), m_time))
 
         return m_time + path_hash
 
@@ -157,7 +158,7 @@ class SmvInputFromFile(SmvInputBase):
             Based on input schema as a StructType
         """
         schema = self.schema()
-        self.smvApp.log.debug("{} schema: {}".format(self.fqn(), schema))
+        smv.logger.debug("{} schema: {}".format(self.fqn(), schema))
 
         if schema is not None:
             return smvhash(self.schema().simpleString())

--- a/src/main/python/smv/smviostrategy.py
+++ b/src/main/python/smv/smviostrategy.py
@@ -17,6 +17,7 @@ import binascii
 
 from pyspark.sql import DataFrame
 from smv.utils import scala_seq_to_list
+import smv
 
 if sys.version_info >= (3, 4):
     ABC = abc.ABC
@@ -129,10 +130,11 @@ class SmvCsvPersistenceStrategy(SmvFileOnHdfsPersistenceStrategy):
         return re.sub("\.csv$", ".schema", self._file_path)
 
     def _write(self, raw_data):
-        jdf = raw_data._jdf
+        smv.logger.info("Output path: {}".format(self._file_path))
         # this call creates both .csv and .schema file from the scala side
-        self.smvApp.j_smvPyClient.persistDF(self._file_path, jdf)
-
+        record_count = self.smvApp.j_smvPyClient.persistDF(self._file_path, raw_data._jdf)
+        smv.logger.info("N: {}".format(record_count))
+    
     def _read(self):
         smvSchemaObj = self.smvApp.j_smvPyClient.getSmvSchema()
         smv_schema = smvSchemaObj.fromFile(self.smvApp.j_smvApp.sc(), self._schema_path)

--- a/src/main/python/smv/smvmodule.py
+++ b/src/main/python/smv/smvmodule.py
@@ -21,6 +21,7 @@ import binascii
 import json
 from datetime import datetime
 
+import smv
 from smv.dqm import SmvDQM
 from smv.error import SmvRuntimeError
 from smv.utils import pickle_lib, lazy_property
@@ -206,7 +207,7 @@ class SmvSparkDfModule(SmvProcessModule):
                 json.loads(validation_result.toJSON()),
                 indent=2, separators=(',', ': ')
             )
-            self.smvApp.log.warn("Nontrivial DQM result:\n{}".format(msg))
+            smv.logger.warn("Nontrivial DQM result:\n{}".format(msg))
         self.module_meta.addDqmValidationResult(validation_result.toJSON())
 
     # All publish related methods should be moved to generic output module class
@@ -221,7 +222,7 @@ class SmvSparkDfModule(SmvProcessModule):
         else:
             queries = [l.strip() for l in self.publishHiveSql().split(";")]
 
-        self.smvApp.log.info("Hive publish query: {}".format(";".join(queries)))
+        smv.logger.info("Hive publish query: {}".format(";".join(queries)))
         def run_query(df):
             # register the dataframe as a temp table.  Will be overwritten on next register.
             df.createOrReplaceTempView("dftable")

--- a/src/main/python/smv/smvmodulerunner.py
+++ b/src/main/python/smv/smvmodulerunner.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import smv
 from smv.modulesvisitor import ModulesVisitor
 from smv.smviostrategy import SmvCsvPersistenceStrategy, SmvJsonOnHdfsPersistenceStrategy
 from smv.smvmetadata import SmvMetaHistory
@@ -25,7 +25,7 @@ class SmvModuleRunner(object):
     def __init__(self, modules, smvApp):
         self.roots = modules
         self.smvApp = smvApp
-        self.log = smvApp.log
+        self.log = smv.logger
         self.visitor = ModulesVisitor(modules)
 
     def run(self, forceRun=False):

--- a/src/main/scala/org/tresamigos/smv/SmvApp.scala
+++ b/src/main/scala/org/tresamigos/smv/SmvApp.scala
@@ -14,8 +14,6 @@
 
 package org.tresamigos.smv
 
-
-import org.apache.log4j.LogManager
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.SparkContext
 
@@ -25,8 +23,6 @@ import org.apache.spark.SparkContext
  * launched using the SmvApp object (defined below)
  */
 class SmvApp(_spark: SparkSession) {
-  val log         = LogManager.getLogger("smv")
-
   val sparkSession = _spark 
 
   val sc         = sparkSession.sparkContext

--- a/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
+++ b/src/main/scala/org/tresamigos/smv/python/SmvPythonProxy.scala
@@ -288,17 +288,15 @@ class SmvPyClient(val j_smvApp: SmvApp) {
   def createFileIOHandler(path: String) =
     new FileIOHandler(j_smvApp.sparkSession, path)
 
-  def persistDF(path: String, dataframe: DataFrame): Unit = {
+  def persistDF(path: String, dataframe: DataFrame): Long = {
     val counter = j_smvApp.sparkSession.sparkContext.longAccumulator
 
     val df      = dataframe.smvPipeCount(counter)
     val handler = new FileIOHandler(j_smvApp.sparkSession, path)
 
     handler.saveAsCsvWithSchema(df, strNullValue = "_SmvStrNull_")
-    j_smvApp.log.info(f"Output path: ${path}")
 
-    val n       = counter.value
-    j_smvApp.log.info(f"N: ${n}")
+    counter.value
   }
 
   private[smv] def writeThroughJDBC(df: DataFrame, url: String, driver: String, tableName: String) = {


### PR DESCRIPTION
Resolves #1512.

Replaces log4j logger with Python standard logger for all logging in SMV:
* Create new logger using Python standard `logging` library and make it available for import at `smv.logger`
* Migrate existing log statements to using `smv.logger` instead of the `SmvApp` logger
* Move final remaining log statement from Scala to Python using the new logger

Removing the cost of py4j from logging improves the latency of `get_graph_json` for a 1000 module project by over 50%. For now logging levels and other configuration will need to be adjusted through code (e.g. `smv.logger.setLevel("DEBUG")`). `logging` supports configuration via yaml, so I created #1517 to load a custom config provided by users.