### PR TITLE
#1498: added get_providers_by_prefix method

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+init-hook=sys.path.append('src/main/python')

--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -233,8 +233,14 @@ class DataSetRepo(object):
 
         return fqns
 
-    def all_providers(self):
+    def _all_providers(self):
+        """scans user libraries and smv libraries for "provider" classes.
+            Returns list of discovered provider classes
+        """
         def is_provider(klass):
+            """A class is a provider if it has `IS_PROVIDER` and is not the base `SmvProvider`
+               which returns empty string for provider type.
+            """
             try:
                 klass_is_provider = (klass.IS_PROVIDER is True) and (klass.provider_type())
             except AttributeError:
@@ -243,11 +249,23 @@ class DataSetRepo(object):
 
         # providers can be in user libs dir or builtin smv
         prov_libs_names = self.smvApp.userLibs() + self.smvApp.smvLibs()
-        prov_list = []
+        prov_dict = {}
 
         for prov_lib_name in prov_libs_names:
             prov_lib = self.load_pymodule(prov_lib_name)
             providers = self._matchingClassesInPyModule(prov_lib, is_provider)
-            prov_list.extend(providers)
+            for p in providers:
+                p_fqn = p.provider_type_fqn()
+                if prov_dict.has_key(p_fqn):
+                    raise SmvRuntimeError("multiple providers with same fqn: " + p_fqn)
+                prov_dict[p_fqn] = p
 
-        return prov_list
+        return prov_dict
+
+    def get_providers_by_prefix(self, fqn_prefix):
+        """Discover all providers in user lib and smv lib that have an provider type fqn
+           starting with the given prefix.
+           Users should use this method instead of using `_all_providers()` directly.
+        """
+        providers = self._all_providers()
+        return [p for (fqn, p) in providers.items() if fqn.startswith(fqn_prefix)]

--- a/src/main/python/smv/datasetrepo.py
+++ b/src/main/python/smv/datasetrepo.py
@@ -256,7 +256,7 @@ class DataSetRepo(object):
             providers = self._matchingClassesInPyModule(prov_lib, is_provider)
             for p in providers:
                 p_fqn = p.provider_type_fqn()
-                if prov_dict.has_key(p_fqn):
+                if p_fqn in prov_dict:
                     raise SmvRuntimeError("multiple providers with same fqn: " + p_fqn)
                 prov_dict[p_fqn] = p
 

--- a/src/main/python/smv/provider.py
+++ b/src/main/python/smv/provider.py
@@ -29,3 +29,22 @@ class SmvProvider(object):
     @staticmethod
     def provider_type(): return ""
 
+    @classmethod
+    def provider_type_fqn(cls):
+        """create a hierarchichal provider type fqn for a given provider class based on the 
+           provider class hierarchy.
+
+           Example (assume `provider_type()` for class X is X):
+             class A(SmvProvider)
+             class B(A)
+             class C(B)
+           In the above example, C's provider type is just `C` but C's provider_type_fqn is "A.B.C" 
+        """
+        # TODO: handle case where we have multiple inheretence with diamond
+        # (IS_PROVIDER would be true for non-provider in the hierarchy in above case)
+        fqn_parts = [c.provider_type() for c in cls.__mro__ if hasattr(c, "IS_PROVIDER")]
+
+        # actual fqn is in reverse of mro traversal and we can ignore "" type at base provider
+        fqn_parts.reverse()
+        fqn_parts = [f for f in fqn_parts if f != ""]
+        return ".".join(fqn_parts)

--- a/src/test/python/testDataSetRepo/bad_provider/library/a.py
+++ b/src/test/python/testDataSetRepo/bad_provider/library/a.py
@@ -1,0 +1,16 @@
+from smv.provider import SmvProvider
+
+
+class MyBaseProvider(SmvProvider):
+    @staticmethod
+    def provider_type(): return "aaa"
+
+# ERROR: two classes below with same provider fqn "aaa.bbb"
+
+class MyConcreteProvider1(MyBaseProvider):
+    @staticmethod
+    def provider_type(): return "bbb"
+
+class MyConcreteProvider2(MyBaseProvider):
+    @staticmethod
+    def provider_type(): return "bbb"

--- a/src/test/python/testDataSetRepo/bad_provider/stage/modules.py
+++ b/src/test/python/testDataSetRepo/bad_provider/stage/modules.py
@@ -1,0 +1,18 @@
+#
+# This file is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from smv import SmvModule
+
+class MyMod(SmvModule):
+    def requiresDS(self): return []
+    def run(self, i): return None


### PR DESCRIPTION
fixes #1498 

added the public `get_providers_by_prefix` method which should be used by clients to get list of available providers.
